### PR TITLE
feat: GitHub in-app update with private repo support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
     <application
         android:name=".LockitApp"

--- a/app/src/main/java/com/lockit/data/updater/AppUpdater.kt
+++ b/app/src/main/java/com/lockit/data/updater/AppUpdater.kt
@@ -1,0 +1,153 @@
+package com.lockit.data.updater
+
+import android.app.DownloadManager
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Environment
+import androidx.core.content.FileProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import java.io.BufferedReader
+import java.net.HttpURLConnection
+import java.net.URL
+
+/**
+ * GitHub Release info.
+ */
+data class GitHubRelease(
+    val versionName: String,
+    val versionCode: Int,
+    val changelog: String,
+    val apkUrl: String?,
+    val downloadSize: Long?,
+)
+
+class AppUpdater(private val context: Context) {
+
+    companion object {
+        private const val GITHUB_REPO = "xqicxx/lockit"
+        private const val RELEASES_API = "https://api.github.com/repos/$GITHUB_REPO/releases/latest"
+    }
+
+    /**
+     * Check GitHub for latest release.
+     * Returns null if no update available.
+     * @param currentVersionCode Current app version code
+     * @param githubToken Optional GitHub personal access token for private repos
+     */
+    suspend fun checkForUpdate(currentVersionCode: Int, githubToken: String? = null): Result<GitHubRelease?> = withContext(Dispatchers.IO) {
+        try {
+            val connection = URL(RELEASES_API).openConnection() as HttpURLConnection
+            connection.requestMethod = "GET"
+            connection.connectTimeout = 10000
+            connection.readTimeout = 10000
+            connection.setRequestProperty("Accept", "application/json")
+
+            // Add Authorization header if token provided (for private repos)
+            if (githubToken != null && githubToken.isNotBlank()) {
+                connection.setRequestProperty("Authorization", "token $githubToken")
+            }
+
+            if (connection.responseCode != 200) {
+                return@withContext Result.failure(Exception("HTTP ${connection.responseCode}"))
+            }
+
+            val response = BufferedReader(connection.inputStream.reader()).readText()
+            val json = JSONObject(response)
+
+            // Parse version from tag_name (e.g., "v1.2.0" or "1.2.0")
+            val tagName = json.getString("tag_name")
+            val versionName = tagName.removePrefix("v")
+
+            // Parse changelog from body
+            val changelog = json.optString("body", "").take(500)
+
+            // Find APK asset
+            val assets = json.getJSONArray("assets")
+            var apkUrl: String? = null
+            var downloadSize: Long? = null
+
+            for (i in 0 until assets.length()) {
+                val asset = assets.getJSONObject(i)
+                val name = asset.getString("name")
+                if (name.endsWith(".apk")) {
+                    apkUrl = asset.getString("browser_download_url")
+                    downloadSize = asset.optLong("size", 0)
+                    break
+                }
+            }
+
+            // Estimate versionCode from version name (simple: major*10000 + minor*100 + patch)
+            val parts = versionName.split(".")
+            val remoteVersionCode = if (parts.size >= 3) {
+                parts[0].toIntOrNull()?.let { major ->
+                    parts[1].toIntOrNull()?.let { minor ->
+                        parts[2].toIntOrNull()?.let { patch ->
+                            major * 10000 + minor * 100 + patch
+                        }
+                    }
+                }
+            } else null
+
+            if (remoteVersionCode == null || remoteVersionCode <= currentVersionCode) {
+                return@withContext Result.success<GitHubRelease?>(null) // No update available
+            }
+
+            Result.success(
+                GitHubRelease(
+                    versionName = versionName,
+                    versionCode = remoteVersionCode,
+                    changelog = changelog,
+                    apkUrl = apkUrl,
+                    downloadSize = downloadSize,
+                )
+            )
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Download APK using system DownloadManager.
+     */
+    fun downloadApk(apkUrl: String, fileName: String = "lockit-update.apk"): Long {
+        val request = DownloadManager.Request(Uri.parse(apkUrl))
+            .setTitle("Lockit Update")
+            .setDescription("Downloading latest version...")
+            .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+            .setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, fileName)
+            .setAllowedOverMetered(true)
+            .setAllowedOverRoaming(true)
+
+        val downloadManager = context.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
+        return downloadManager.enqueue(request)
+    }
+
+    /**
+     * Get APK file URI for installation.
+     */
+    fun getApkUri(fileName: String = "lockit-update.apk"): Uri {
+        val file = java.io.File(
+            Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
+            fileName
+        )
+        return FileProvider.getUriForFile(
+            context,
+            "${context.packageName}.fileprovider",
+            file
+        )
+    }
+
+    /**
+     * Start APK installation intent.
+     */
+    fun installApk(uri: Uri) {
+        val intent = Intent(Intent.ACTION_VIEW)
+            .setDataAndType(uri, "application/vnd.android.package-archive")
+            .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        context.startActivity(intent)
+    }
+}

--- a/app/src/main/java/com/lockit/data/updater/AppUpdater.kt
+++ b/app/src/main/java/com/lockit/data/updater/AppUpdater.kt
@@ -9,7 +9,6 @@ import androidx.core.content.FileProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
-import java.io.BufferedReader
 import java.net.HttpURLConnection
 import java.net.URL
 
@@ -24,7 +23,9 @@ data class GitHubRelease(
     val downloadSize: Long?,
 )
 
-class AppUpdater(private val context: Context) {
+class AppUpdater(context: Context) {
+    // Use applicationContext to prevent memory leaks
+    private val context = context.applicationContext
 
     companion object {
         private const val GITHUB_REPO = "xqicxx/lockit"
@@ -38,8 +39,9 @@ class AppUpdater(private val context: Context) {
      * @param githubToken Optional GitHub personal access token for private repos
      */
     suspend fun checkForUpdate(currentVersionCode: Int, githubToken: String? = null): Result<GitHubRelease?> = withContext(Dispatchers.IO) {
+        var connection: HttpURLConnection? = null
         try {
-            val connection = URL(RELEASES_API).openConnection() as HttpURLConnection
+            connection = URL(RELEASES_API).openConnection() as HttpURLConnection
             connection.requestMethod = "GET"
             connection.connectTimeout = 10000
             connection.readTimeout = 10000
@@ -54,7 +56,8 @@ class AppUpdater(private val context: Context) {
                 return@withContext Result.failure(Exception("HTTP ${connection.responseCode}"))
             }
 
-            val response = BufferedReader(connection.inputStream.reader()).readText()
+            // Use use{} to ensure inputStream is closed properly
+            val response = connection.inputStream.bufferedReader().use { it.readText() }
             val json = JSONObject(response)
 
             // Parse version from tag_name (e.g., "v1.2.0" or "1.2.0")
@@ -79,17 +82,9 @@ class AppUpdater(private val context: Context) {
                 }
             }
 
-            // Estimate versionCode from version name (simple: major*10000 + minor*100 + patch)
+            // Parse version components for proper comparison
             val parts = versionName.split(".")
-            val remoteVersionCode = if (parts.size >= 3) {
-                parts[0].toIntOrNull()?.let { major ->
-                    parts[1].toIntOrNull()?.let { minor ->
-                        parts[2].toIntOrNull()?.let { patch ->
-                            major * 10000 + minor * 100 + patch
-                        }
-                    }
-                }
-            } else null
+            val remoteVersionCode = parseVersionCode(parts)
 
             if (remoteVersionCode == null || remoteVersionCode <= currentVersionCode) {
                 return@withContext Result.success<GitHubRelease?>(null) // No update available
@@ -106,13 +101,32 @@ class AppUpdater(private val context: Context) {
             )
         } catch (e: Exception) {
             Result.failure(e)
+        } finally {
+            connection?.disconnect()
         }
     }
 
     /**
-     * Download APK using system DownloadManager.
+     * Parse version code from version string parts.
+     * Uses a safer formula that avoids collisions: major*1000000 + minor*1000 + patch
+     * Each segment can be up to 999 without collision.
      */
-    fun downloadApk(apkUrl: String, fileName: String = "lockit-update.apk"): Long {
+    private fun parseVersionCode(parts: List<String>): Int? {
+        if (parts.isEmpty()) return null
+
+        val major = parts.getOrNull(0)?.toIntOrNull() ?: 0
+        val minor = parts.getOrNull(1)?.toIntOrNull() ?: 0
+        val patch = parts.getOrNull(2)?.toIntOrNull() ?: 0
+
+        // Safer formula: each segment can be up to 999
+        return major * 1000000 + minor * 1000 + patch
+    }
+
+    /**
+     * Download APK using system DownloadManager.
+     * @param githubToken Optional token for private repos (added as Authorization header)
+     */
+    fun downloadApk(apkUrl: String, githubToken: String? = null, fileName: String = "lockit-update.apk"): Long {
         val request = DownloadManager.Request(Uri.parse(apkUrl))
             .setTitle("Lockit Update")
             .setDescription("Downloading latest version...")
@@ -120,6 +134,11 @@ class AppUpdater(private val context: Context) {
             .setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, fileName)
             .setAllowedOverMetered(true)
             .setAllowedOverRoaming(true)
+
+        // Add Authorization header for private repos
+        if (!githubToken.isNullOrBlank()) {
+            request.addRequestHeader("Authorization", "token $githubToken")
+        }
 
         val downloadManager = context.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
         return downloadManager.enqueue(request)

--- a/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
@@ -38,6 +38,8 @@ import androidx.compose.ui.unit.sp
 import com.lockit.LockitApp
 import com.lockit.data.database.LockitDatabase
 import com.lockit.data.sync.GoogleDriveSyncManager
+import com.lockit.data.updater.AppUpdater
+import com.lockit.data.updater.GitHubRelease
 import com.lockit.domain.model.Credential
 import com.lockit.ui.components.BrutalistButton
 import com.lockit.ui.components.BrutalistConfirmDialog
@@ -72,6 +74,15 @@ fun ConfigScreen(
     var showLockDialog by remember { mutableStateOf(false) }
     var showChangePinDialog by remember { mutableStateOf(false) }
     var toastMessage by remember { mutableStateOf<String?>(null) }
+
+    // App update
+    val appUpdater = remember { AppUpdater(context) }
+    var isCheckingUpdate by remember { mutableStateOf(false) }
+    var availableUpdate by remember { mutableStateOf<GitHubRelease?>(null) }
+    var showUpdateDialog by remember { mutableStateOf(false) }
+    var isDownloading by remember { mutableStateOf(false) }
+    var githubTokenCredentialName by remember { mutableStateOf("GITHUB_TOKEN") }
+    var showTokenConfigDialog by remember { mutableStateOf(false) }
 
     // Google Drive sync
     val syncManager = remember { GoogleDriveSyncManager(context) }
@@ -128,6 +139,37 @@ fun ConfigScreen(
             onSuccess = {
                 showChangePinDialog = false
                 toastMessage = "PASSWORD_CHANGED_SUCCESS"
+            },
+        )
+    }
+
+    // Update dialog
+    if (showUpdateDialog && availableUpdate != null) {
+        UpdateDialog(
+            release = availableUpdate!!,
+            onDismiss = { showUpdateDialog = false },
+            onDownload = {
+                showUpdateDialog = false
+                isDownloading = true
+                val apkUrl = availableUpdate?.apkUrl
+                if (apkUrl != null) {
+                    appUpdater.downloadApk(apkUrl)
+                    toastMessage = "DOWNLOAD_STARTED"
+                    isDownloading = false
+                }
+            },
+        )
+    }
+
+    // GitHub Token config dialog
+    if (showTokenConfigDialog) {
+        GitHubTokenConfigDialog(
+            currentName = githubTokenCredentialName,
+            onDismiss = { showTokenConfigDialog = false },
+            onSave = { newName ->
+                githubTokenCredentialName = newName
+                showTokenConfigDialog = false
+                toastMessage = "TOKEN_SOURCE_SET: $newName"
             },
         )
     }
@@ -344,6 +386,91 @@ fun ConfigScreen(
                     "ARGON2_ITERATIONS" to "3",
                     "ARGON2_PARALLELISM" to "4",
                 ),
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Update Section
+            ConfigSection(
+                title = "UPGRADE",
+                content = {
+                    Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        // Current version info
+                        val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
+                        val currentVersion = packageInfo.versionName ?: "Unknown"
+                        val currentVersionCode = packageInfo.longVersionCode.toInt()
+                        Row(
+                            modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                        ) {
+                            Text(
+                                text = "当前版本",
+                                fontFamily = JetBrainsMonoFamily,
+                                fontSize = 10.sp,
+                                color = Color.Gray,
+                            )
+                            Text(
+                                text = "$currentVersion ($currentVersionCode)",
+                                fontFamily = JetBrainsMonoFamily,
+                                fontSize = 10.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = IndustrialOrange,
+                            )
+                        }
+
+                        // GitHub Token configuration
+                        Row(
+                            modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                text = "Token来源",
+                                fontFamily = JetBrainsMonoFamily,
+                                fontSize = 10.sp,
+                                color = Color.Gray,
+                            )
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Text(
+                                    text = githubTokenCredentialName,
+                                    fontFamily = JetBrainsMonoFamily,
+                                    fontSize = 10.sp,
+                                    fontWeight = FontWeight.Bold,
+                                    color = IndustrialOrange,
+                                    modifier = Modifier.clickable { showTokenConfigDialog = true },
+                                )
+                            }
+                        }
+
+                        BrutalistButton(
+                            text = if (isCheckingUpdate) "检查中..." else if (isDownloading) "下载中..." else "检查更新",
+                            onClick = {
+                                isCheckingUpdate = true
+                                scope.launch {
+                                    // Read GitHub Token from vault
+                                    val tokenCredential = app.vaultManager.getAllCredentials()
+                                        .first()
+                                        .find { it.name == githubTokenCredentialName }
+                                    val token = tokenCredential?.value
+                                    val result = appUpdater.checkForUpdate(currentVersionCode, token)
+                                    isCheckingUpdate = false
+                                    if (result.isFailure) {
+                                        toastMessage = "检查失败: ${result.exceptionOrNull()?.message}"
+                                    } else if (result.getOrNull() == null) {
+                                        toastMessage = "已是最新版本"
+                                    } else {
+                                        availableUpdate = result.getOrNull()
+                                        showUpdateDialog = true
+                                    }
+                                }
+                            },
+                            variant = ButtonVariant.Primary,
+                            modifier = Modifier.fillMaxWidth(),
+                            useMonoFont = true,
+                            enabled = !isCheckingUpdate && !isDownloading,
+                        )
+                    }
+                },
             )
 
             Spacer(modifier = Modifier.height(24.dp))
@@ -704,6 +831,163 @@ private fun ConfigSection(
 
         if (content != null) {
             content()
+        }
+    }
+}
+
+/**
+ * Update dialog showing new version info and download button.
+ */
+@Composable
+private fun UpdateDialog(
+    release: GitHubRelease,
+    onDismiss: () -> Unit,
+    onDownload: () -> Unit,
+) {
+    androidx.compose.ui.window.Dialog(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(White)
+                .border(2.dp, Color.Black)
+                .padding(24.dp),
+        ) {
+            Text(
+                text = "发现新版本 ${release.versionName}",
+                fontFamily = JetBrainsMonoFamily,
+                fontWeight = FontWeight.Bold,
+                fontSize = 14.sp,
+                color = IndustrialOrange,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Changelog
+            if (release.changelog.isNotBlank()) {
+                Text(
+                    text = "更新日志",
+                    fontFamily = JetBrainsMonoFamily,
+                    fontSize = 10.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = Primary,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(100.dp)
+                        .border(1.dp, Color.Gray)
+                        .padding(8.dp),
+                ) {
+                    Text(
+                        text = release.changelog,
+                        fontFamily = JetBrainsMonoFamily,
+                        fontSize = 9.sp,
+                        color = Color.Gray,
+                    )
+                }
+            }
+
+            // Download size
+            if (release.downloadSize != null && release.downloadSize > 0) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "大小: ${release.downloadSize / 1024 / 1024} MB",
+                    fontFamily = JetBrainsMonoFamily,
+                    fontSize = 9.sp,
+                    color = Color.Gray,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                BrutalistButton(
+                    text = "稍后",
+                    onClick = onDismiss,
+                    variant = ButtonVariant.Secondary,
+                    modifier = Modifier.weight(1f),
+                    useMonoFont = true,
+                )
+                BrutalistButton(
+                    text = "下载更新",
+                    onClick = onDownload,
+                    variant = ButtonVariant.Primary,
+                    modifier = Modifier.weight(1f),
+                    useMonoFont = true,
+                    enabled = release.apkUrl != null,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Dialog for configuring GitHub Token credential source.
+ */
+@Composable
+private fun GitHubTokenConfigDialog(
+    currentName: String,
+    onDismiss: () -> Unit,
+    onSave: (String) -> Unit,
+) {
+    var newName by remember { mutableStateOf(currentName) }
+
+    androidx.compose.ui.window.Dialog(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(White)
+                .border(2.dp, Color.Black)
+                .padding(24.dp),
+        ) {
+            Text(
+                text = "配置 GitHub Token",
+                fontFamily = JetBrainsMonoFamily,
+                fontWeight = FontWeight.Bold,
+                fontSize = 14.sp,
+                color = Primary,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Text(
+                text = "输入存储 GitHub Token 的凭据名称。Lockit 将自动读取该凭据的值作为 API 认证令牌（支持私有仓库）。",
+                fontFamily = JetBrainsMonoFamily,
+                fontSize = 10.sp,
+                color = Color.Gray,
+                lineHeight = 14.sp,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+
+            BrutalistTextField(
+                value = newName,
+                onValueChange = { newName = it },
+                label = "TOKEN_CREDENTIAL_NAME",
+                placeholder = "例如: GITHUB_TOKEN",
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                BrutalistButton(
+                    text = "取消",
+                    onClick = onDismiss,
+                    variant = ButtonVariant.Secondary,
+                    modifier = Modifier.weight(1f),
+                    useMonoFont = true,
+                )
+                BrutalistButton(
+                    text = "保存",
+                    onClick = { onSave(newName) },
+                    variant = ButtonVariant.Primary,
+                    modifier = Modifier.weight(1f),
+                    useMonoFont = true,
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
@@ -404,7 +404,7 @@ fun ConfigScreen(
                             horizontalArrangement = Arrangement.SpaceBetween,
                         ) {
                             Text(
-                                text = "当前版本",
+                                text = "CURRENT_VERSION",
                                 fontFamily = JetBrainsMonoFamily,
                                 fontSize = 10.sp,
                                 color = Color.Gray,
@@ -425,7 +425,7 @@ fun ConfigScreen(
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
                             Text(
-                                text = "Token来源",
+                                text = "TOKEN_SOURCE",
                                 fontFamily = JetBrainsMonoFamily,
                                 fontSize = 10.sp,
                                 color = Color.Gray,
@@ -443,7 +443,7 @@ fun ConfigScreen(
                         }
 
                         BrutalistButton(
-                            text = if (isCheckingUpdate) "检查中..." else if (isDownloading) "下载中..." else "检查更新",
+                            text = if (isCheckingUpdate) "CHECKING..." else if (isDownloading) "DOWNLOADING..." else "CHECK_UPDATE",
                             onClick = {
                                 isCheckingUpdate = true
                                 scope.launch {
@@ -455,9 +455,9 @@ fun ConfigScreen(
                                     val result = appUpdater.checkForUpdate(currentVersionCode, token)
                                     isCheckingUpdate = false
                                     if (result.isFailure) {
-                                        toastMessage = "检查失败: ${result.exceptionOrNull()?.message}"
+                                        toastMessage = "CHECK_FAILED: ${result.exceptionOrNull()?.message}"
                                     } else if (result.getOrNull() == null) {
-                                        toastMessage = "已是最新版本"
+                                        toastMessage = "ALREADY_LATEST_VERSION"
                                     } else {
                                         availableUpdate = result.getOrNull()
                                         showUpdateDialog = true
@@ -853,7 +853,7 @@ private fun UpdateDialog(
                 .padding(24.dp),
         ) {
             Text(
-                text = "发现新版本 ${release.versionName}",
+                text = "NEW_VERSION: ${release.versionName}",
                 fontFamily = JetBrainsMonoFamily,
                 fontWeight = FontWeight.Bold,
                 fontSize = 14.sp,
@@ -864,7 +864,7 @@ private fun UpdateDialog(
             // Changelog
             if (release.changelog.isNotBlank()) {
                 Text(
-                    text = "更新日志",
+                    text = "CHANGELOG",
                     fontFamily = JetBrainsMonoFamily,
                     fontSize = 10.sp,
                     fontWeight = FontWeight.Bold,
@@ -891,7 +891,7 @@ private fun UpdateDialog(
             if (release.downloadSize != null && release.downloadSize > 0) {
                 Spacer(modifier = Modifier.height(8.dp))
                 Text(
-                    text = "大小: ${release.downloadSize / 1024 / 1024} MB",
+                    text = "SIZE: ${release.downloadSize / 1024 / 1024} MB",
                     fontFamily = JetBrainsMonoFamily,
                     fontSize = 9.sp,
                     color = Color.Gray,
@@ -905,14 +905,14 @@ private fun UpdateDialog(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 BrutalistButton(
-                    text = "稍后",
+                    text = "LATER",
                     onClick = onDismiss,
                     variant = ButtonVariant.Secondary,
                     modifier = Modifier.weight(1f),
                     useMonoFont = true,
                 )
                 BrutalistButton(
-                    text = "下载更新",
+                    text = "DOWNLOAD_UPDATE",
                     onClick = onDownload,
                     variant = ButtonVariant.Primary,
                     modifier = Modifier.weight(1f),
@@ -944,7 +944,7 @@ private fun GitHubTokenConfigDialog(
                 .padding(24.dp),
         ) {
             Text(
-                text = "配置 GitHub Token",
+                text = "CONFIG_GITHUB_TOKEN",
                 fontFamily = JetBrainsMonoFamily,
                 fontWeight = FontWeight.Bold,
                 fontSize = 14.sp,
@@ -953,7 +953,7 @@ private fun GitHubTokenConfigDialog(
             Spacer(modifier = Modifier.height(12.dp))
 
             Text(
-                text = "输入存储 GitHub Token 的凭据名称。Lockit 将自动读取该凭据的值作为 API 认证令牌（支持私有仓库）。",
+                text = "Enter the credential name storing your GitHub Token. Lockit will read its value for API authentication (supports private repos).",
                 fontFamily = JetBrainsMonoFamily,
                 fontSize = 10.sp,
                 color = Color.Gray,
@@ -965,7 +965,7 @@ private fun GitHubTokenConfigDialog(
                 value = newName,
                 onValueChange = { newName = it },
                 label = "TOKEN_CREDENTIAL_NAME",
-                placeholder = "例如: GITHUB_TOKEN",
+                placeholder = "e.g. GITHUB_TOKEN",
             )
             Spacer(modifier = Modifier.height(24.dp))
 
@@ -974,14 +974,14 @@ private fun GitHubTokenConfigDialog(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 BrutalistButton(
-                    text = "取消",
+                    text = "CANCEL",
                     onClick = onDismiss,
                     variant = ButtonVariant.Secondary,
                     modifier = Modifier.weight(1f),
                     useMonoFont = true,
                 )
                 BrutalistButton(
-                    text = "保存",
+                    text = "SAVE",
                     onClick = { onSave(newName) },
                     variant = ButtonVariant.Primary,
                     modifier = Modifier.weight(1f),

--- a/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
@@ -1,7 +1,10 @@
 package com.lockit.ui.screens.config
 
+import android.app.DownloadManager
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import com.google.android.gms.auth.api.signin.GoogleSignIn
@@ -83,6 +86,7 @@ fun ConfigScreen(
     var isDownloading by remember { mutableStateOf(false) }
     var githubTokenCredentialName by remember { mutableStateOf("GITHUB_TOKEN") }
     var showTokenConfigDialog by remember { mutableStateOf(false) }
+    var lastCheckedToken by remember { mutableStateOf<String?>(null) } // Store token for download
 
     // Google Drive sync
     val syncManager = remember { GoogleDriveSyncManager(context) }
@@ -153,7 +157,7 @@ fun ConfigScreen(
                 isDownloading = true
                 val apkUrl = availableUpdate?.apkUrl
                 if (apkUrl != null) {
-                    appUpdater.downloadApk(apkUrl)
+                    appUpdater.downloadApk(apkUrl, lastCheckedToken)
                     toastMessage = "DOWNLOAD_STARTED"
                     isDownloading = false
                 }
@@ -395,10 +399,21 @@ fun ConfigScreen(
                 title = "UPGRADE",
                 content = {
                     Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                        // Current version info
-                        val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
-                        val currentVersion = packageInfo.versionName ?: "Unknown"
-                        val currentVersionCode = packageInfo.longVersionCode.toInt()
+                        // Current version info with safe handling
+                        val packageInfo = try {
+                            context.packageManager.getPackageInfo(context.packageName, 0)
+                        } catch (e: Exception) {
+                            null
+                        }
+                        val currentVersion = packageInfo?.versionName ?: "Unknown"
+                        val currentVersionCode = packageInfo?.let {
+                            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+                                it.longVersionCode.toInt()
+                            } else {
+                                @Suppress("DEPRECATION")
+                                it.versionCode
+                            }
+                        } ?: 0
                         Row(
                             modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
                             horizontalArrangement = Arrangement.SpaceBetween,
@@ -447,11 +462,18 @@ fun ConfigScreen(
                             onClick = {
                                 isCheckingUpdate = true
                                 scope.launch {
+                                    // Check vault is unlocked before reading credentials
+                                    if (!app.vaultManager.isUnlocked()) {
+                                        toastMessage = "VAULT_LOCKED"
+                                        isCheckingUpdate = false
+                                        return@launch
+                                    }
                                     // Read GitHub Token from vault
                                     val tokenCredential = app.vaultManager.getAllCredentials()
                                         .first()
                                         .find { it.name == githubTokenCredentialName }
                                     val token = tokenCredential?.value
+                                    lastCheckedToken = token // Store for download
                                     val result = appUpdater.checkForUpdate(currentVersionCode, token)
                                     isCheckingUpdate = false
                                     if (result.isFailure) {


### PR DESCRIPTION
## Summary
- Add GitHub Releases API integration for in-app updates
- Support private repository access via GitHub Token stored in Lockit vault
- Add UPGRADE section in Settings with version info and update check
- Use Android DownloadManager for APK downloads

## Changes
- `AppUpdater.kt`: GitHub Releases API client with optional token authentication
- `ConfigScreen.kt`: UPGRADE section, UpdateDialog, GitHubTokenConfigDialog
- `AndroidManifest.xml`: REQUEST_INSTALL_PACKAGES permission

## Test plan
- [ ] Build debug APK passes
- [ ] Install on emulator succeeds
- [ ] Update check button works (without token for public repos)
- [ ] Token configuration dialog opens
- [ ] Changelog display in UpdateDialog

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)