### PR TITLE
feat: Add GitHub credential type

### DIFF
--- a/app/src/main/java/com/lockit/domain/model/CredentialType.kt
+++ b/app/src/main/java/com/lockit/domain/model/CredentialType.kt
@@ -49,6 +49,7 @@ enum class CredentialType(
             CredentialField("TOKEN_TYPE", "Select token type", presets = listOf(
                 "Personal Access Token", "SSH Key", "OAuth App", "GitHub App",
             ), isDropdown = true, editable = false),
+            CredentialField("ACCOUNT", "GitHub username (e.g. octocat)..."),
             CredentialField("TOKEN_VALUE", "Paste token or SSH key..."),
             CredentialField("SCOPE", "Select scopes (multi-select)", presets = listOf(
                 "repo", "workflow", "admin:org", "admin:repo_hook", "write:packages",
@@ -56,7 +57,6 @@ enum class CredentialType(
                 "user:email", "user:follow", "read:org", "write:org",
                 "public_repo", "repo:status", "repo_deployment", "security_events",
             ), isDropdown = false, showAsChips = true),
-            CredentialField("ACCOUNT", "GitHub username (e.g. octocat)..."),
         ),
     ),
     Account(
@@ -299,7 +299,7 @@ val CredentialType.requiredFieldIndices: Set<Int>
         CredentialType.Account -> setOf(0, 3)
         CredentialType.Password -> setOf(0, 3)
         // GitHub: NAME + TOKEN_VALUE required
-        CredentialType.GitHub -> setOf(0, 2)
+        CredentialType.GitHub -> setOf(0, 3)
         // Single-field types: only the first field is required
         CredentialType.Phone -> setOf(0)       // just phone number
         CredentialType.BankCard -> setOf(0)

--- a/app/src/main/java/com/lockit/domain/model/CredentialType.kt
+++ b/app/src/main/java/com/lockit/domain/model/CredentialType.kt
@@ -39,6 +39,26 @@ enum class CredentialType(
             CredentialField("SECRET_VALUE", "Paste or enter the secret..."),
         ),
     ),
+    GitHub(
+        "GITHUB", "github",
+        "Store GitHub credentials for private repo access, CI/CD, and agent git operations. Supports PAT, SSH, OAuth, and GitHub App.",
+        listOf(
+            CredentialField("NAME", "e.g. GITHUB_TOKEN, CI_BOT", presets = listOf(
+                "GITHUB_TOKEN", "CI_BOT", "RELEASE_BOT", "PERSONAL_PAT", "ORG_PAT", "CUSTOM",
+            ), isDropdown = true),
+            CredentialField("TOKEN_TYPE", "Select token type", presets = listOf(
+                "Personal Access Token", "SSH Key", "OAuth App", "GitHub App",
+            ), isDropdown = true, editable = false),
+            CredentialField("TOKEN_VALUE", "Paste token or SSH key..."),
+            CredentialField("SCOPE", "Select scopes (multi-select)", presets = listOf(
+                "repo", "workflow", "admin:org", "admin:repo_hook", "write:packages",
+                "read:packages", "delete:packages", "gist", "user", "read:user",
+                "user:email", "user:follow", "read:org", "write:org",
+                "public_repo", "repo:status", "repo_deployment", "security_events",
+            ), isDropdown = false, showAsChips = true),
+            CredentialField("ACCOUNT", "GitHub username (e.g. octocat)..."),
+        ),
+    ),
     Account(
         "ACCOUNT", "account_circle",
         "Store login credentials for websites or apps. Agent can use these to auto-fill login forms.",
@@ -278,6 +298,8 @@ val CredentialType.requiredFieldIndices: Set<Int>
         // Account/Password: username+password mutual dependency
         CredentialType.Account -> setOf(0, 3)
         CredentialType.Password -> setOf(0, 3)
+        // GitHub: NAME + TOKEN_VALUE required
+        CredentialType.GitHub -> setOf(0, 2)
         // Single-field types: only the first field is required
         CredentialType.Phone -> setOf(0)       // just phone number
         CredentialType.BankCard -> setOf(0)


### PR DESCRIPTION
## Summary
- Add new CredentialType.GitHub with dedicated fields for GitHub credentials
- Supports Personal Access Token, SSH Key, OAuth App, GitHub App
- Multi-select scope chips: repo, workflow, admin:org, etc.

## Changes
- `CredentialType.kt`: Added GitHub enum entry with 5 fields
- Updated requiredFieldIndices for GitHub type

## Fields
| Field | Type | Description |
|-------|------|-------------|
| NAME | Dropdown | GITHUB_TOKEN, CI_BOT, etc. |
| TOKEN_TYPE | Dropdown | PAT, SSH, OAuth, GitHub App |
| TOKEN_VALUE | Secret | Token or key content |
| SCOPE | Multi-select chips | repo, workflow, admin:org... |
| ACCOUNT | Text | GitHub username |

## Use Cases
- Private repo authentication
- CI/CD pipeline credentials
- Agent git operations

## Test plan
- [x] Build passes
- [x] Lint passes
- [ ] Manual testing: create GitHub credential in app
- [ ] Verify AppUpdater reads GitHub token correctly

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)