### PR TITLE
chore: Remove redundant CredentialTypes (BearerToken, BasicAuth)

### DIFF
--- a/app/src/main/java/com/lockit/domain/model/CredentialType.kt
+++ b/app/src/main/java/com/lockit/domain/model/CredentialType.kt
@@ -154,28 +154,6 @@ enum class CredentialType(
             CredentialField("PRIVATE_KEY", "Paste private key..."),
         ),
     ),
-    BearerToken(
-        "BEARER_TOKEN", "badge",
-        "Store bearer tokens for OAuth2/API auth. Agent injects into Authorization: Bearer header.",
-        listOf(
-            CredentialField("NAME", "e.g. API_BEARER, AUTH_TOKEN"),
-            CredentialField("SERVICE", "e.g. my-api, staging..."),
-            CredentialField("KEY_IDENTIFIER", "e.g. default, production...", presets = listOf(
-                "default", "production", "staging", "development",
-            ), isDropdown = true),
-            CredentialField("TOKEN_VALUE", "Paste or enter the bearer token..."),
-        ),
-    ),
-    BasicAuth(
-        "BASIC_AUTH", "account_circle",
-        "Store HTTP Basic Auth credentials. Agent uses these for protected API endpoints.",
-        listOf(
-            CredentialField("USERNAME", "Enter username..."),
-            CredentialField("SERVICE", "e.g. admin-panel, jenkins..."),
-            CredentialField("REALM", "Realm (optional)..."),
-            CredentialField("PASSWORD", "Enter password..."),
-        ),
-    ),
     WebhookSecret(
         "WEBHOOK_SECRET", "webhook",
         "Store webhook signing secrets for verifying incoming webhooks. Agent validates webhook payloads.",


### PR DESCRIPTION
## Summary
- Remove `BearerToken` type (covered by `Token`)
- Remove `BasicAuth` type (covered by `Account`)
- 19 types → 17 types, eliminating duplication

## Changes
- `CredentialType.kt`: Removed 2 redundant enum entries

## Rationale
| Type | Covered By | Reason |
|------|-----------|--------|
| BearerToken | Token | Both store tokens for API headers |
| BasicAuth | Account | Both are username+password |

## Test plan
- [x] Build passes
- [x] Lint passes
- [ ] Verify remaining types work in app

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)