### PR TITLE
fix: Account card rendering and ChipGroup flow layout

### DIFF
--- a/app/src/main/java/com/lockit/ui/components/CredentialCard.kt
+++ b/app/src/main/java/com/lockit/ui/components/CredentialCard.kt
@@ -530,6 +530,43 @@ private fun CredentialContent(
             OptionalFieldRow("SCOPE", scope)
         }
 
+        CredentialType.Account -> {
+            // Account: show USERNAME + EMAIL + PASSWORD (password needs reveal)
+            val username = fields.getNotBlank(0) ?: credential.name
+            val email = fields.getNotBlank(2)
+            val password = fields.getNotBlank(3) ?: CredentialDefaults.FIELD_NOT_SET
+
+            FieldValueBox(label = "USERNAME", value = username)
+
+            // EMAIL - optional, show if present
+            if (email != null) {
+                Spacer(modifier = Modifier.height(8.dp))
+                FieldValueBox(label = "EMAIL", value = email)
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // PASSWORD - revealable
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                FieldLabel("PASSWORD")
+                IconButtonBox(
+                    icon = if (isRevealed) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                    description = if (isRevealed) "Hide" else "Reveal",
+                    onClick = { if (!isRevealed) onNeedReveal() else onHide() },
+                )
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            FieldValueBox(
+                label = "",
+                value = if (isRevealed) password else maskPlaceholder,
+                maxLines = 3,
+            )
+        }
+
         else -> {
             // Default: single value with reveal toggle
             // Use pre-parsed fields instead of extractSecretValue to avoid redundant parsing

--- a/app/src/main/java/com/lockit/ui/components/CredentialFormComponents.kt
+++ b/app/src/main/java/com/lockit/ui/components/CredentialFormComponents.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -146,6 +148,7 @@ fun DropdownWithCustomInput(
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun ChipGroup(
     label: String,
@@ -169,10 +172,11 @@ fun ChipGroup(
         )
         Spacer(modifier = androidx.compose.ui.Modifier.height(8.dp))
 
-        // Chips
-        Row(
+        // Chips - use FlowRow for automatic wrapping
+        FlowRow(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
             options.forEach { option ->
                 Chip(


### PR DESCRIPTION
## Summary
- Account type card now shows USERNAME + EMAIL + PASSWORD
- ChipGroup uses FlowRow for automatic line wrapping

## Changes
- CredentialCard.kt: Add Account type rendering branch
- CredentialFormComponents.kt: Use FlowRow instead of Row

## Test plan
- [ ] Build passes
- [ ] Account card shows all fields correctly
- [ ] Service preset chips wrap to multiple lines

Closes #14, Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)