### PR TITLE
fix: simplify homepage footer, remove misleading orange sync text

### DIFF
--- a/app/src/main/java/com/lockit/ui/screens/vault_explorer/VaultExplorerScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/vault_explorer/VaultExplorerScreen.kt
@@ -375,10 +375,9 @@ fun VaultExplorerScreen(
                 Spacer(modifier = Modifier.height(16.dp))
                 TerminalFooter(
                     lines = listOf(
-                        stringResource(R.string.explorer_syncing) to IndustrialOrange,
                         stringResource(R.string.explorer_daemon) to Color.Gray,
-                        stringResource(R.string.explorer_total_credentials) + " ${credentials.size} " + stringResource(R.string.explorer_ready) to Color.Gray,
-                        if (services.isNotEmpty()) stringResource(R.string.explorer_services) + " ${services.joinToString(", ")}" to Color.Gray
+                        stringResource(R.string.explorer_total_credentials) + " ${credentials.size}" to Color.Gray,
+                        if (services.isNotEmpty()) stringResource(R.string.explorer_services) + " ${services.take(3).joinToString(", ")}${if (services.size > 3) "..." else ""}" to Color.Gray
                         else stringResource(R.string.explorer_no_services) to Color.Gray,
                     ),
                 )


### PR DESCRIPTION
## Summary
- Remove misleading orange "> SYNCING_METADATA..." text from footer
- All footer text now gray for consistent appearance

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)