### PR TITLE
fix: clear toast message before locking vault

### DIFF
--- a/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
@@ -219,6 +219,7 @@ fun ConfigScreen(
                         BrutalistButton(
                             text = stringResource(R.string.config_lock_vault),
                             onClick = {
+                                toastMessage = null
                                 app.vaultManager.lockVault()
                                 onLockVault()
                             },


### PR DESCRIPTION
## Summary
- Clear pending toast messages when lock vault button clicked

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)