### PR TITLE
fix: preserve repos service selection state across navigation

### DIFF
--- a/app/src/main/java/com/lockit/ui/MainActivity.kt
+++ b/app/src/main/java/com/lockit/ui/MainActivity.kt
@@ -164,6 +164,7 @@ private fun MainFlow(app: LockitApp) {
     var currentScreen by remember { mutableStateOf(AppScreen.Repos) }
     var selectedCredentialId by remember { mutableStateOf<String?>(null) }
     var editingCredentialId by remember { mutableStateOf<String?>(null) }
+    var reposSelectedService by remember { mutableStateOf<String?>(null) }
 
     LaunchedEffect(currentScreen) {
         if (currentScreen != AppScreen.SecretDetails) {
@@ -179,9 +180,11 @@ private fun MainFlow(app: LockitApp) {
         currentScreen = currentScreen,
         selectedCredentialId = selectedCredentialId,
         editingCredentialId = editingCredentialId,
+        reposSelectedService = reposSelectedService,
         onScreenChange = { currentScreen = it },
         onCredentialSelected = { id -> selectedCredentialId = id },
         onCredentialEdit = { id -> editingCredentialId = id; currentScreen = AppScreen.EditCredential },
+        onReposServiceSelected = { reposSelectedService = it },
         onLockVault = {
             app.vaultManager.lockVault()
             isVaultUnlocked = false
@@ -196,9 +199,11 @@ private fun MainScaffold(
     currentScreen: AppScreen,
     selectedCredentialId: String?,
     editingCredentialId: String?,
+    reposSelectedService: String?,
     onScreenChange: (AppScreen) -> Unit,
     onCredentialSelected: (String) -> Unit,
     onCredentialEdit: (String) -> Unit,
+    onReposServiceSelected: (String?) -> Unit,
     onLockVault: () -> Unit,
 ) {
     // Handle Android back button for secondary screens
@@ -240,6 +245,8 @@ private fun MainScaffold(
                 AppScreen.Repos -> ReposScreen(
                     app = app,
                     onCredentialEdit = onCredentialEdit,
+                    selectedService = reposSelectedService,
+                    onServiceSelected = onReposServiceSelected,
                 )
 
                 AppScreen.VaultExplorer -> VaultExplorerScreen(

--- a/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
@@ -238,6 +238,8 @@ fun ReposScreen(
     app: LockitApp,
     modifier: Modifier = Modifier,
     onCredentialEdit: (String) -> Unit = {},
+    selectedService: String? = null,
+    onServiceSelected: (String?) -> Unit = {},
     viewModel: ReposViewModel = viewModel(factory = ReposViewModelFactory(app)),
 ) {
     val credentialList by viewModel.credentials.collectAsStateWithLifecycle()
@@ -257,13 +259,11 @@ fun ReposScreen(
     val serviceCount = servicesByGroup.size
     val credentialCount = credentialList.size
 
-    var selectedService by remember { mutableStateOf<String?>(null) }
-    var searchQuery by remember { mutableStateOf("") }
-
     // Handle Android back button when viewing a service's credentials
     BackHandler(enabled = selectedService != null) {
-        selectedService = null
+        onServiceSelected(null)
     }
+    var searchQuery by remember { mutableStateOf("") }
     val clipboardManager = LocalClipboardManager.current
     val context = LocalContext.current
     val view = LocalView.current
@@ -360,7 +360,7 @@ fun ReposScreen(
     }
 
     fun onServiceRowClick(serviceName: String) {
-        selectedService = serviceName
+        onServiceSelected(serviceName)
     }
 
     Column(
@@ -525,7 +525,7 @@ fun ReposScreen(
 
                 BackButtonRow(
                     onBack = {
-                        selectedService = null
+                        onServiceSelected(null)
                         revealedCredentialIds.clear()
                         revealedEmailPasswordMap.clear()
                     },


### PR DESCRIPTION
## Summary
- Lift selectedService state to MainFlow level
- Service selection persists when navigating away and back

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)