### PR TITLE
fix: prevent UI jump when PIN error message appears

### DIFF
--- a/app/src/main/java/com/lockit/ui/screens/vault_unlock/VaultUnlockScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/vault_unlock/VaultUnlockScreen.kt
@@ -456,33 +456,39 @@ fun VaultUnlockScreen(
                         }
                 }
 
-                // Error message
-                viewModel.errorMessage?.let { errorKey ->
-                    val localizedError = getLocalizedErrorMessage(errorKey, context)
-                    if (localizedError != null) {
-                        Spacer(modifier = Modifier.height(16.dp))
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .border(1.dp, TacticalRed)
-                                .padding(10.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        ) {
-                            Text(
-                                text = "!",
-                                fontFamily = JetBrainsMonoFamily,
-                                fontSize = 12.sp,
-                                fontWeight = FontWeight.Bold,
-                                color = TacticalRed,
-                            )
-                            Text(
-                                text = localizedError,
-                                fontFamily = JetBrainsMonoFamily,
-                                fontSize = 9.sp,
-                                color = TacticalRed,
-                                modifier = Modifier.weight(1f),
-                            )
+                // Error message area - fixed height to prevent UI jump
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(50.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    viewModel.errorMessage?.let { errorKey ->
+                        val localizedError = getLocalizedErrorMessage(errorKey, context)
+                        if (localizedError != null) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .border(1.dp, TacticalRed)
+                                    .padding(10.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            ) {
+                                Text(
+                                    text = "!",
+                                    fontFamily = JetBrainsMonoFamily,
+                                    fontSize = 12.sp,
+                                    fontWeight = FontWeight.Bold,
+                                    color = TacticalRed,
+                                )
+                                Text(
+                                    text = localizedError,
+                                    fontFamily = JetBrainsMonoFamily,
+                                    fontSize = 9.sp,
+                                    color = TacticalRed,
+                                    modifier = Modifier.weight(1f),
+                                )
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Reserve fixed height for error message area
- No layout shift when error appears

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)