### PR TITLE
fix: show download location in toast after starting download

### DIFF
--- a/app/src/main/java/com/lockit/data/updater/AppUpdater.kt
+++ b/app/src/main/java/com/lockit/data/updater/AppUpdater.kt
@@ -23,6 +23,15 @@ data class GitHubRelease(
     val downloadSize: Long?,
 )
 
+/**
+ * Download result containing file path and URI for installation.
+ */
+data class DownloadResult(
+    val downloadId: Long,
+    val filePath: String,
+    val fileUri: Uri,
+)
+
 class AppUpdater(context: Context) {
     // Use applicationContext to prevent memory leaks
     private val context = context.applicationContext
@@ -30,6 +39,14 @@ class AppUpdater(context: Context) {
     companion object {
         private const val GITHUB_REPO = "xqicxx/lockit-android"
         private const val RELEASES_API = "https://api.github.com/repos/$GITHUB_REPO/releases/latest"
+        const val DOWNLOAD_FILE_NAME = "lockit-update.apk"
+    }
+
+    /**
+     * Get the download directory path for user information.
+     */
+    fun getDownloadDirectory(): String {
+        return Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).absolutePath
     }
 
     /**

--- a/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
@@ -159,7 +159,8 @@ fun ConfigScreen(
                 val apkUrl = availableUpdate?.apkUrl
                 if (apkUrl != null) {
                     appUpdater.downloadApk(apkUrl, lastCheckedToken)
-                    toastMessage = context.getString(R.string.toast_download_started)
+                    val downloadDir = appUpdater.getDownloadDirectory()
+                    toastMessage = "${context.getString(R.string.toast_download_started)}\n${context.getString(R.string.toast_download_location)} $downloadDir"
                     isDownloading = false
                 }
             },

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -153,6 +153,7 @@
     <string name="toast_sync_complete">同步完成</string>
     <string name="toast_signed_out">已退出</string>
     <string name="toast_download_started">下载已开始</string>
+    <string name="toast_download_location">下载位置:</string>
     <string name="toast_check_failed">检查失败:</string>
     <string name="toast_already_latest">已是最新版本</string>
     <string name="toast_vault_locked">密码库已锁定</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -153,6 +153,7 @@
     <string name="toast_sync_complete">SYNC_COMPLETE</string>
     <string name="toast_signed_out">SIGNED_OUT</string>
     <string name="toast_download_started">DOWNLOAD_STARTED</string>
+    <string name="toast_download_location">DOWNLOAD_LOCATION:</string>
     <string name="toast_check_failed">CHECK_FAILED:</string>
     <string name="toast_already_latest">ALREADY_LATEST_VERSION</string>
     <string name="toast_vault_locked">VAULT_LOCKED</string>


### PR DESCRIPTION
## Summary
- Add getDownloadDirectory() method to AppUpdater
- Display download path in toast message
- User now knows where APK file is saved

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)