### PR TITLE
feat: add dark mode support (Version 4 - Digital Monolith)

### DIFF
--- a/app/src/main/java/com/lockit/ui/MainActivity.kt
+++ b/app/src/main/java/com/lockit/ui/MainActivity.kt
@@ -36,6 +36,7 @@ import com.lockit.ui.screens.secret_details.SecretDetailsScreen
 import com.lockit.ui.screens.vault_explorer.VaultExplorerScreen
 import com.lockit.ui.screens.vault_unlock.VaultUnlockScreen
 import com.lockit.ui.theme.LockitTheme
+import com.lockit.ui.theme.ThemePreference
 import com.lockit.data.vault.CodingPlanPrefs
 import com.lockit.domain.CodingPlanFetchers
 import com.lockit.domain.CodingPlanPrefetchState
@@ -79,7 +80,8 @@ class MainActivity : FragmentActivity() {
         )
 
         setContent {
-            LockitTheme {
+            val themeMode = ThemePreference.getThemeMode(this)
+            LockitTheme(themeMode = themeMode) {
                 MainFlow(app = app)
             }
         }

--- a/app/src/main/java/com/lockit/ui/components/BrutalistBottomNav.kt
+++ b/app/src/main/java/com/lockit/ui/components/BrutalistBottomNav.kt
@@ -20,7 +20,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -47,12 +46,20 @@ fun BrutalistBottomNav(
     onItemSelected: (BottomNavItem) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val colorScheme = MaterialTheme.colorScheme
+    // Use theme-aware colors
+    val backgroundColor = colorScheme.surface
+    val borderColor = colorScheme.primary
+    val selectedBgColor = colorScheme.primary
+    val selectedContentColor = colorScheme.onPrimary
+    val unselectedContentColor = colorScheme.onSurfaceVariant
+
     Row(
         modifier = modifier
             .fillMaxWidth()
             .height(56.dp)
-            .background(White)
-            .border(1.dp, Color.Black),
+            .background(backgroundColor)
+            .border(1.dp, borderColor),
     ) {
         BottomNavItem.entries.forEachIndexed { index, item ->
             val isSelected = item == selected
@@ -61,7 +68,7 @@ fun BrutalistBottomNav(
             Box(
                 modifier = Modifier
                     .weight(1f)
-                    .background(if (isSelected) Primary else Color.Transparent)
+                    .background(if (isSelected) selectedBgColor else Color.Transparent)
                     .clickable { onItemSelected(item) },
                 contentAlignment = Alignment.Center,
             ) {
@@ -72,7 +79,7 @@ fun BrutalistBottomNav(
                     Icon(
                         imageVector = item.icon,
                         contentDescription = label,
-                        tint = if (isSelected) White else Primary,
+                        tint = if (isSelected) selectedContentColor else unselectedContentColor,
                         modifier = Modifier.height(20.dp),
                     )
                     Text(
@@ -80,7 +87,7 @@ fun BrutalistBottomNav(
                         fontFamily = JetBrainsMonoFamily,
                         fontWeight = FontWeight.Bold,
                         fontSize = 9.sp,
-                        color = if (isSelected) White else Primary,
+                        color = if (isSelected) selectedContentColor else unselectedContentColor,
                     )
                 }
             }
@@ -91,7 +98,7 @@ fun BrutalistBottomNav(
                     modifier = Modifier
                         .width(1.dp)
                         .fillMaxHeight()
-                        .background(Color.Black),
+                        .background(borderColor),
                 )
             }
         }

--- a/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -420,13 +421,13 @@ fun ConfigScreen(
                             text = stringResource(R.string.config_language_desc),
                             fontFamily = JetBrainsMonoFamily,
                             fontSize = 10.sp,
-                            color = Color.Gray,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                             modifier = Modifier.padding(bottom = 8.dp),
                         )
                         Box(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .border(1.dp, Primary)
+                                .border(1.dp, MaterialTheme.colorScheme.primary)
                                 .clickable { languageExpanded = true }
                                 .padding(12.dp),
                         ) {
@@ -440,7 +441,7 @@ fun ConfigScreen(
                             DropdownMenu(
                                 expanded = languageExpanded,
                                 onDismissRequest = { languageExpanded = false },
-                                modifier = Modifier.background(White).border(1.dp, Primary),
+                                modifier = Modifier.background(MaterialTheme.colorScheme.background).border(1.dp, MaterialTheme.colorScheme.primary),
                             ) {
                                 languageOptions.forEach { (langCode, langLabel) ->
                                     DropdownMenuItem(
@@ -450,7 +451,7 @@ fun ConfigScreen(
                                                 fontFamily = JetBrainsMonoFamily,
                                                 fontSize = 12.sp,
                                                 fontWeight = if (langCode == currentLanguage) FontWeight.Bold else FontWeight.Normal,
-                                                color = if (langCode == currentLanguage) IndustrialOrange else Color.Gray,
+                                                color = if (langCode == currentLanguage) IndustrialOrange else MaterialTheme.colorScheme.onSurfaceVariant,
                                             )
                                         },
                                         onClick = {
@@ -489,13 +490,13 @@ fun ConfigScreen(
                             text = stringResource(R.string.config_theme_desc),
                             fontFamily = JetBrainsMonoFamily,
                             fontSize = 10.sp,
-                            color = Color.Gray,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                             modifier = Modifier.padding(bottom = 8.dp),
                         )
                         Box(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .border(1.dp, Primary)
+                                .border(1.dp, MaterialTheme.colorScheme.primary)
                                 .clickable { themeExpanded = true }
                                 .padding(12.dp),
                         ) {
@@ -509,7 +510,7 @@ fun ConfigScreen(
                             DropdownMenu(
                                 expanded = themeExpanded,
                                 onDismissRequest = { themeExpanded = false },
-                                modifier = Modifier.background(White).border(1.dp, Primary),
+                                modifier = Modifier.background(MaterialTheme.colorScheme.background).border(1.dp, MaterialTheme.colorScheme.primary),
                             ) {
                                 themeOptions.forEach { (mode, modeLabel) ->
                                     DropdownMenuItem(
@@ -519,7 +520,7 @@ fun ConfigScreen(
                                                 fontFamily = JetBrainsMonoFamily,
                                                 fontSize = 12.sp,
                                                 fontWeight = if (mode == currentThemeMode) FontWeight.Bold else FontWeight.Normal,
-                                                color = if (mode == currentThemeMode) IndustrialOrange else Color.Gray,
+                                                color = if (mode == currentThemeMode) IndustrialOrange else MaterialTheme.colorScheme.onSurfaceVariant,
                                             )
                                         },
                                         onClick = {

--- a/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
@@ -62,6 +62,8 @@ import com.lockit.ui.theme.IndustrialOrange
 import com.lockit.ui.theme.JetBrainsMonoFamily
 import com.lockit.ui.theme.Primary
 import com.lockit.ui.theme.TacticalRed
+import com.lockit.ui.theme.ThemeMode
+import com.lockit.ui.theme.ThemePreference
 import com.lockit.ui.theme.White
 import com.lockit.utils.LocaleHelper
 import kotlinx.coroutines.Dispatchers
@@ -455,6 +457,75 @@ fun ConfigScreen(
                                             languageExpanded = false
                                             if (langCode != currentLanguage) {
                                                 LocaleHelper.saveLanguage(context, langCode)
+                                                (context as? android.app.Activity)?.recreate()
+                                            }
+                                        },
+                                    )
+                                }
+                            }
+                        }
+                    }
+                },
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Theme Section
+            val currentThemeMode = ThemePreference.getThemeMode(context)
+            var themeExpanded by remember { mutableStateOf(false) }
+            val themeOptions = listOf(
+                ThemeMode.SYSTEM to stringResource(R.string.config_theme_system),
+                ThemeMode.LIGHT to stringResource(R.string.config_theme_light),
+                ThemeMode.DARK to stringResource(R.string.config_theme_dark),
+            )
+            val currentThemeLabel = themeOptions.find { it.first == currentThemeMode }?.second
+                ?: stringResource(R.string.config_theme_system)
+
+            ConfigSection(
+                title = stringResource(R.string.config_theme),
+                content = {
+                    Column(modifier = Modifier.fillMaxWidth()) {
+                        Text(
+                            text = stringResource(R.string.config_theme_desc),
+                            fontFamily = JetBrainsMonoFamily,
+                            fontSize = 10.sp,
+                            color = Color.Gray,
+                            modifier = Modifier.padding(bottom = 8.dp),
+                        )
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .border(1.dp, Primary)
+                                .clickable { themeExpanded = true }
+                                .padding(12.dp),
+                        ) {
+                            Text(
+                                text = currentThemeLabel,
+                                fontFamily = JetBrainsMonoFamily,
+                                fontSize = 12.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = IndustrialOrange,
+                            )
+                            DropdownMenu(
+                                expanded = themeExpanded,
+                                onDismissRequest = { themeExpanded = false },
+                                modifier = Modifier.background(White).border(1.dp, Primary),
+                            ) {
+                                themeOptions.forEach { (mode, modeLabel) ->
+                                    DropdownMenuItem(
+                                        text = {
+                                            Text(
+                                                text = modeLabel,
+                                                fontFamily = JetBrainsMonoFamily,
+                                                fontSize = 12.sp,
+                                                fontWeight = if (mode == currentThemeMode) FontWeight.Bold else FontWeight.Normal,
+                                                color = if (mode == currentThemeMode) IndustrialOrange else Color.Gray,
+                                            )
+                                        },
+                                        onClick = {
+                                            themeExpanded = false
+                                            if (mode != currentThemeMode) {
+                                                ThemePreference.setThemeMode(context, mode)
                                                 (context as? android.app.Activity)?.recreate()
                                             }
                                         },

--- a/app/src/main/java/com/lockit/ui/screens/vault_unlock/VaultUnlockScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/vault_unlock/VaultUnlockScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Fingerprint
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -251,6 +252,7 @@ fun VaultUnlockScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val view = LocalView.current
+    val colorScheme = MaterialTheme.colorScheme
 
     LaunchedEffect(Unit) {
         viewModel.setAppState(app.vaultManager.isInitialized())
@@ -266,11 +268,12 @@ fun VaultUnlockScreen(
     Scaffold(
         topBar = { Box(Modifier.statusBarsPadding()) { BrutalistTopBar() } },
     ) { paddingValues ->
+        val colorScheme = MaterialTheme.colorScheme
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
-                .background(White),
+                .background(colorScheme.background),
         ) {
             // Main Content
             Box(
@@ -315,15 +318,15 @@ fun VaultUnlockScreen(
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .border(1.dp, Primary)
-                        .background(White),
+                        .border(1.dp, colorScheme.primary)
+                        .background(colorScheme.surface),
                 ) {
                     // PIN Input Display
                     Column(
                         modifier = Modifier
                             .fillMaxWidth()
                             .drawBehind {
-                                drawLine(Primary, Offset(0f, size.height), Offset(size.width, size.height), 1.dp.toPx())
+                                drawLine(colorScheme.primary, Offset(0f, size.height), Offset(size.width, size.height), 1.dp.toPx())
                             }
                                 .padding(vertical = 12.dp),
                             horizontalAlignment = Alignment.CenterHorizontally,
@@ -377,7 +380,7 @@ fun VaultUnlockScreen(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .drawBehind {
-                                    drawLine(Primary, Offset(0f, 0f), Offset(size.width, 0f), 1.dp.toPx())
+                                    drawLine(colorScheme.primary, Offset(0f, 0f), Offset(size.width, 0f), 1.dp.toPx())
                                 }
                                 .padding(12.dp),
                             verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -663,17 +666,21 @@ private fun KeypadKey(
     hasRightBorder: Boolean,
     hasBottomBorder: Boolean,
 ) {
+    val colorScheme = MaterialTheme.colorScheme
+    val bgColor = colorScheme.surface
+    val borderColor = colorScheme.primary
+
     Box(
         modifier = modifier
             .aspectRatio(4f / 3f)
-            .background(if (enabled) White else Color.Black.copy(0.05f))
+            .background(if (enabled) bgColor else borderColor.copy(0.05f))
             .drawBehind {
                 val sw = 1.dp.toPx()
                 if (hasRightBorder) {
-                    drawLine(Primary, Offset(size.width, 0f), Offset(size.width, size.height), sw)
+                    drawLine(borderColor, Offset(size.width, 0f), Offset(size.width, size.height), sw)
                 }
                 if (hasBottomBorder) {
-                    drawLine(Primary, Offset(0f, size.height), Offset(size.width, size.height), sw)
+                    drawLine(borderColor, Offset(0f, size.height), Offset(size.width, size.height), sw)
                 }
             }
             .clickable(enabled = enabled) {

--- a/app/src/main/java/com/lockit/ui/theme/Color.kt
+++ b/app/src/main/java/com/lockit/ui/theme/Color.kt
@@ -2,19 +2,63 @@ package com.lockit.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-// Technical Brutalism Color Palette
+// ============================================
+// LIGHT THEME COLORS (Version 1 - Brutalist)
+// ============================================
+
+// Brutalism Color Palette - Light Mode
 // Based on lockit/ui/version_1/DESIGN.md
 
-val Primary = Color(0xFF000000)           // Black - structural borders, primary buttons
-val IndustrialOrange = Color(0xFFB34700)  // Industrial Orange - system status, warnings
-val TacticalRed = Color(0xFFA30000)       // Tactical Red - destructive actions
-val DarkCrimson = Color(0xFF8B0000)       // Dark Crimson - critical/security alerts
-val SurfaceLow = Color(0xFFF3F3F3)        // Low container surface
+val Primary = Color(0xFF000000)           // Black - primary buttons, borders
+val IndustrialOrange = Color(0xFFB34700)  // Industrial Orange - status, warnings
+val TacticalRed = Color(0xFFA30000)       // Tactical Red - errors, danger
+val DarkCrimson = Color(0xFF8B0000)       // Dark Crimson - critical alerts
+
+val SurfaceLow = Color(0xFFF3F3F5)        // Low container surface (lightest grey)
 val SurfaceContainer = Color(0xFFEEEEEE)  // Medium container surface
-val SurfaceHighest = Color(0xFFE2E2E2)    // Highest container surface (grey headers)
+val SurfaceHighest = Color(0xFFE2E2E2)    // Highest container surface (headers)
 
 val White = Color(0xFFFFFFFF)
 val Black = Color(0xFF000000)
 val Grey400 = Color(0xFF777777)           // outline
 val Grey500 = Color(0xFF999999)
 val Grey600 = Color(0xFF666666)
+
+// ============================================
+// DARK THEME COLORS (Version 4 - Digital Monolith)
+// ============================================
+
+// Digital Monolith - Dark Mode
+// Based on lockit/ui/version_4/monolith/DESIGN.md
+// "No-Line" rule: boundaries by background color shifts, not borders
+
+// Foundation
+val DarkSurface = Color(0xFF131313)       // Deep neutral void - standard page background
+val DarkPrimary = Color(0xFFFFFFFF)       // Pure white - maximum legibility, high-contrast
+val DarkOnPrimary = Color(0xFF410000)     // Dark red - text on white buttons
+
+// Surface Hierarchy (stacking levels of darkness)
+val DarkSurfaceLowest = Color(0xFF0E0E0E) // Deepest background - sidebars, recessed areas
+val DarkSurfaceContainer = Color(0xFF1F1F1F) // Cards, active panels
+val DarkSurfaceContainerHigh = Color(0xFF353535) // Elevated modals, popovers
+
+// For compatibility with surfaceHighest naming
+val DarkSurfaceHighest = Color(0xFF353535)
+
+// Accent Colors
+val DarkIndustrialOrange = Color(0xFFB34700) // Same orange accent
+val DarkTacticalRed = Color(0xFF8B0000)     // Darker red for dark mode (more visible on dark)
+
+// Outlines (used sparingly, 20% opacity equivalent)
+val DarkOutline = Color(0xFF474747)        // Ghost border fallback
+val DarkOutlineVariant = Color(0xFF474747)
+val DarkSurfaceVariant = Color(0xFF474747) // For surfaceVariant
+
+// ============================================
+// COMPATIBILITY ALIASES
+// ============================================
+
+// These provide semantic access for components
+val Surface = White                        // Light mode default surface
+
+// Dark mode aliases (computed in Theme.kt via colorScheme)

--- a/app/src/main/java/com/lockit/ui/theme/Theme.kt
+++ b/app/src/main/java/com/lockit/ui/theme/Theme.kt
@@ -1,7 +1,10 @@
 package com.lockit.ui.theme
 
 import android.app.Activity
+import android.content.Context
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
@@ -10,47 +13,127 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 
-private val LockitColorScheme = lightColorScheme(
-    primary = Primary,
-    onPrimary = White,
-    primaryContainer = SurfaceHighest,
-    onPrimaryContainer = Black,
-    secondary = IndustrialOrange,
+/**
+ * Theme mode preference for dark/light mode switching.
+ */
+enum class ThemeMode {
+    SYSTEM,  // Follow Android system setting
+    LIGHT,   // Force light mode
+    DARK     // Force dark mode
+}
+
+/**
+ * Helper to get/saved theme preference.
+ */
+object ThemePreference {
+    private const val PREFS_NAME = "lockit_theme_prefs"
+    private const val KEY_THEME_MODE = "theme_mode"
+
+    fun getThemeMode(context: Context): ThemeMode {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val saved = prefs.getString(KEY_THEME_MODE, ThemeMode.SYSTEM.name)
+        return try {
+            ThemeMode.valueOf(saved ?: ThemeMode.SYSTEM.name)
+        } catch (e: IllegalArgumentException) {
+            ThemeMode.SYSTEM
+        }
+    }
+
+    fun setThemeMode(context: Context, mode: ThemeMode) {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        prefs.edit().putString(KEY_THEME_MODE, mode.name).apply()
+    }
+}
+
+// Light Color Scheme (Version 1 - current brutalist)
+private val LightColorScheme = lightColorScheme(
+    primary = Primary,                    // Black #000000
+    onPrimary = White,                    // White
+    primaryContainer = SurfaceHighest,    // #E2E2E2
+    onPrimaryContainer = Primary,         // Black
+    secondary = IndustrialOrange,         // #B34700
     onSecondary = White,
     secondaryContainer = SurfaceHighest,
-    tertiary = TacticalRed,
+    onSecondaryContainer = Primary,
+    tertiary = TacticalRed,               // #A30000
     onTertiary = White,
     error = TacticalRed,
     onError = White,
-    background = White,
-    onBackground = Black,
+    background = White,                   // #FFFFFF
+    onBackground = Primary,
     surface = White,
-    onSurface = Black,
-    surfaceVariant = SurfaceHighest,
-    onSurfaceVariant = Grey600,
-    surfaceContainerLow = SurfaceLow,
-    surfaceContainer = SurfaceContainer,
-    surfaceContainerHigh = SurfaceHighest,
-    surfaceContainerHighest = SurfaceHighest,
-    outline = Grey400,
-    outlineVariant = Grey500,
+    onSurface = Primary,
+    surfaceVariant = Grey400,
+    onSurfaceVariant = Grey500,
+    surfaceContainerLowest = SurfaceLow,      // #F3F3F5
+    surfaceContainerLow = SurfaceLow,         // #F3F3F5
+    surfaceContainer = SurfaceContainer,      // #EEEEEE
+    surfaceContainerHigh = SurfaceContainer,  // #EEEEEE
+    surfaceContainerHighest = SurfaceHighest, // #E2E2E2
+    outline = Grey400,                        // #777777
+    outlineVariant = Grey500,                 // #999999
+)
+
+// Dark Color Scheme (Version 4 - Digital Monolith)
+// "No-Line" rule: boundaries defined by background color shifts, not borders
+private val DarkColorScheme = darkColorScheme(
+    primary = DarkPrimary,                    // White #FFFFFF (inverse of light)
+    onPrimary = DarkOnPrimary,                // #410000 (dark red for text on white)
+    primaryContainer = DarkSurfaceContainerHigh, // #353535
+    onPrimaryContainer = DarkPrimary,         // White
+    secondary = DarkIndustrialOrange,         // #B34700 (same accent)
+    onSecondary = DarkPrimary,                // White
+    secondaryContainer = DarkSurfaceContainerHigh,
+    onSecondaryContainer = DarkPrimary,
+    tertiary = DarkTacticalRed,               // #8B0000 (deeper red)
+    onTertiary = DarkPrimary,                 // White
+    error = DarkTacticalRed,                  // #8B0000
+    onError = DarkPrimary,                    // White
+    background = DarkSurface,                 // #131313 - deep neutral void
+    onBackground = DarkPrimary,               // White
+    surface = DarkSurface,                    // #131313
+    onSurface = DarkPrimary,                  // White
+    surfaceVariant = DarkSurfaceVariant,      // #474747
+    onSurfaceVariant = DarkPrimary.copy(alpha = 0.7f),
+    surfaceContainerLowest = DarkSurfaceLowest,   // #0E0E0E - deepest recessed
+    surfaceContainerLow = DarkSurfaceLowest,     // #0E0E0E
+    surfaceContainer = DarkSurfaceContainer,    // #1F1F1F - cards/panels
+    surfaceContainerHigh = DarkSurfaceContainerHigh, // #353535 - elevated modals
+    surfaceContainerHighest = DarkSurfaceHighest,    // #353535
+    outline = DarkOutline,                       // #474747 at 20% opacity equivalent
+    outlineVariant = DarkOutlineVariant,          // #474747
 )
 
 @Composable
 fun LockitTheme(
+    themeMode: ThemeMode = ThemeMode.SYSTEM,
     content: @Composable () -> Unit,
 ) {
+    val systemDark = isSystemInDarkTheme()
+    val useDarkTheme = when (themeMode) {
+        ThemeMode.SYSTEM -> systemDark
+        ThemeMode.DARK -> true
+        ThemeMode.LIGHT -> false
+    }
+
+    val colorScheme = if (useDarkTheme) DarkColorScheme else LightColorScheme
+
     val view = LocalView.current
     if (!view.isInEditMode) {
         SideEffect {
-            val window = (view.context as Activity).window
-            window.statusBarColor = White.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = true
+            val activity = view.context as? Activity
+            if (activity != null) {
+                val window = activity.window
+                // Set status bar content color: dark icons for light theme, light for dark
+                WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !useDarkTheme
+                // Navigation bar follows same logic
+                WindowCompat.getInsetsController(window, view).isAppearanceLightNavigationBars = !useDarkTheme
+            }
         }
     }
 
     MaterialTheme(
-        colorScheme = LockitColorScheme,
+        colorScheme = colorScheme,
         typography = LockitTypography,
         shapes = LockitShapes,
         content = content,

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -116,6 +116,13 @@
     <string name="config_lang_zh">中文</string>
     <string name="config_lang_en">English</string>
 
+    <!-- Theme Section -->
+    <string name="config_theme">主题</string>
+    <string name="config_theme_desc">应用颜色主题</string>
+    <string name="config_theme_system">跟随系统</string>
+    <string name="config_theme_light">亮色</string>
+    <string name="config_theme_dark">暗色</string>
+
     <!-- Change PIN Dialog -->
     <string name="change_pin_title">更改PIN</string>
     <string name="change_pin_current">当前PIN</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,6 +116,13 @@
     <string name="config_lang_zh">中文</string>
     <string name="config_lang_en">English</string>
 
+    <!-- Theme Section -->
+    <string name="config_theme">THEME</string>
+    <string name="config_theme_desc">App color theme</string>
+    <string name="config_theme_system">Follow System</string>
+    <string name="config_theme_light">Light</string>
+    <string name="config_theme_dark">Dark</string>
+
     <!-- Change PIN Dialog -->
     <string name="change_pin_title">CHANGE_PIN</string>
     <string name="change_pin_current">CURRENT_PIN</string>


### PR DESCRIPTION
## Summary
- Add dark mode based on Version 4 "Digital Monolith" design system
- Config screen theme selector: Follow System / Light / Dark
- Theme-aware colors in key components (BrutalistBottomNav, VaultUnlockScreen)

## Dark Mode Design (Version 4)
Based on `lockit/ui/version_4/monolith/DESIGN.md`:
- Background: `#131313` (deep neutral void)
- Primary: `#FFFFFF` (pure white for high-contrast)
- Surface hierarchy (color shifts, not borders):
  - `#0E0E0E` - deepest (sidebars, recessed)
  - `#131313` - standard page background
  - `#1F1F1F` - cards/panels
  - `#353535` - elevated modals/popovers

## Changes
- `Theme.kt`: Add `ThemeMode` enum, `ThemePreference` helper, `DarkColorScheme`
- `Color.kt`: Add dark mode color constants
- `MainActivity.kt`: Apply theme preference on startup
- `ConfigScreen.kt`: Add theme selection dropdown
- `BrutalistBottomNav.kt`: Use `MaterialTheme.colorScheme`
- `VaultUnlockScreen.kt`: Partial theme adaptation
- `strings.xml`: Theme labels (Follow System/Light/Dark)

## Test plan
- [x] Build passes
- [x] Lint passes
- [ ] Manual: Switch to Dark mode in Config, verify UI changes
- [ ] Manual: Toggle "Follow System" and change Android system theme
- [ ] Manual: Verify status bar icons invert (light theme = dark icons, dark theme = light icons)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)