### PR TITLE
fix: repos back navigation - clear selectedService on bottom nav click

### DIFF
--- a/app/src/main/java/com/lockit/ui/MainActivity.kt
+++ b/app/src/main/java/com/lockit/ui/MainActivity.kt
@@ -249,7 +249,11 @@ private fun MainScaffold(
                         when (item) {
                             BottomNavItem.Keys -> onScreenChange(AppScreen.VaultExplorer)
                             BottomNavItem.Config -> onScreenChange(AppScreen.Config)
-                            BottomNavItem.Repos -> onScreenChange(AppScreen.Repos)
+                            BottomNavItem.Repos -> {
+                                // Clear selected service when user explicitly navigates to Repos home
+                                onReposServiceSelected(null)
+                                onScreenChange(AppScreen.Repos)
+                            }
                             BottomNavItem.Logs -> onScreenChange(AppScreen.Logs)
                         }
                     },


### PR DESCRIPTION
## Summary
- Clear reposSelectedService when user clicks Repos in bottom nav
- Ensures landing on Repos home (service list) not stuck in detail view

## Changes
- `MainActivity.kt`: Added reposSelectedService clear in bottom nav click handler

## Test plan
- [x] Build passes
- [ ] Test: Repos → service detail → bottom nav Repos → should land on home
- [ ] Test: Verify Issue #59 full flow

Related to #59 (partial fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)