### PR TITLE
fix: download update failure with status tracking and error handling

### DIFF
--- a/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
@@ -93,6 +93,8 @@ fun ConfigScreen(
     var availableUpdate by remember { mutableStateOf<GitHubRelease?>(null) }
     var showUpdateDialog by remember { mutableStateOf(false) }
     var isDownloading by remember { mutableStateOf(false) }
+    var downloadId by remember { mutableStateOf<Long?>(null) }
+    var downloadError by remember { mutableStateOf<String?>(null) }
     var githubTokenCredentialName by remember { mutableStateOf("GITHUB_TOKEN") }
     var showTokenConfigDialog by remember { mutableStateOf(false) }
     var lastCheckedToken by remember { mutableStateOf<String?>(null) } // Store token for download
@@ -151,21 +153,57 @@ fun ConfigScreen(
         )
     }
 
-    // Update dialog
+    // Update dialog - Pre-fetch string resources to avoid context usage in coroutine after UI disposal
     if (showUpdateDialog && availableUpdate != null) {
+        val apkUrl = availableUpdate?.apkUrl
+        val versionName = availableUpdate?.versionName
+        val strDownloadComplete = context.getString(R.string.toast_download_complete)
+        val strDownloadFailed = context.getString(R.string.toast_download_failed)
+        val strDownloadStarted = context.getString(R.string.toast_download_started)
+        val strDownloadLocation = context.getString(R.string.toast_download_location)
+        val strNoApkUrl = context.getString(R.string.toast_no_apk_url)
         UpdateDialog(
             release = availableUpdate!!,
             onDismiss = { showUpdateDialog = false },
             onDownload = {
-                showUpdateDialog = false
-                isDownloading = true
-                val apkUrl = availableUpdate?.apkUrl
-                val versionName = availableUpdate?.versionName
-                if (apkUrl != null) {
-                    appUpdater.downloadApk(apkUrl, versionName, lastCheckedToken)
+                if (apkUrl == null) {
+                    toastMessage = strNoApkUrl
+                    showUpdateDialog = false
+                } else {
+                    showUpdateDialog = false
+                    isDownloading = true
+                    downloadError = null
+                    val newDownloadId = appUpdater.downloadApk(apkUrl, versionName, lastCheckedToken)
+                    downloadId = newDownloadId
                     val downloadDir = appUpdater.getDownloadDirectory()
-                    toastMessage = "${context.getString(R.string.toast_download_started)}\n${context.getString(R.string.toast_download_location)} $downloadDir"
-                    isDownloading = false
+                    toastMessage = "$strDownloadStarted\n$strDownloadLocation $downloadDir"
+                    scope.launch {
+                        var status = DownloadManager.STATUS_PENDING
+                        while (status == DownloadManager.STATUS_PENDING || status == DownloadManager.STATUS_RUNNING) {
+                            kotlinx.coroutines.delay(2000)
+                            status = appUpdater.getDownloadStatus(newDownloadId)
+                        }
+                        isDownloading = false
+                        when (status) {
+                            DownloadManager.STATUS_SUCCESSFUL -> {
+                                toastMessage = strDownloadComplete
+                            }
+                            DownloadManager.STATUS_FAILED -> {
+                                val errorReason = appUpdater.getDownloadErrorReason(newDownloadId)
+                                val errorMsg = when (errorReason) {
+                                    DownloadManager.ERROR_INSUFFICIENT_SPACE -> "Insufficient storage space"
+                                    DownloadManager.ERROR_HTTP_DATA_ERROR -> "HTTP data error"
+                                    else -> "Download failed (error $errorReason)"
+                                }
+                                downloadError = errorMsg
+                                toastMessage = "$strDownloadFailed: $errorMsg"
+                            }
+                            DownloadManager.STATUS_PAUSED -> {
+                                downloadError = "Download paused (network issue)"
+                                toastMessage = "$strDownloadFailed: Network connection lost"
+                            }
+                        }
+                    }
                 }
             },
         )

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -164,6 +164,9 @@
     <string name="toast_signed_out">已退出</string>
     <string name="toast_download_started">下载已开始</string>
     <string name="toast_download_location">下载位置:</string>
+    <string name="toast_download_failed">下载失败</string>
+    <string name="toast_download_complete">下载完成</string>
+    <string name="toast_no_apk_url">发布版本无APK链接</string>
     <string name="toast_check_failed">检查失败:</string>
     <string name="toast_already_latest">已是最新版本</string>
     <string name="toast_vault_locked">密码库已锁定</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -164,6 +164,9 @@
     <string name="toast_signed_out">SIGNED_OUT</string>
     <string name="toast_download_started">DOWNLOAD_STARTED</string>
     <string name="toast_download_location">DOWNLOAD_LOCATION:</string>
+    <string name="toast_download_failed">DOWNLOAD_FAILED</string>
+    <string name="toast_download_complete">DOWNLOAD_COMPLETE</string>
+    <string name="toast_no_apk_url">NO_APK_URL_IN_RELEASE</string>
     <string name="toast_check_failed">CHECK_FAILED:</string>
     <string name="toast_already_latest">ALREADY_LATEST_VERSION</string>
     <string name="toast_vault_locked">VAULT_LOCKED</string>


### PR DESCRIPTION
## Summary
- Add downloadId tracking to monitor download status
- Handle STATUS_PAUSED (network lost) to prevent infinite loop
- Pre-fetch string resources to avoid context crash in coroutine
- Show specific error messages for different failure reasons

## Changes
- `ConfigScreen.kt`: Download monitoring with status polling
- `strings.xml`: Added toast messages for download states
- `strings.xml` (zh): Chinese translations

## Test plan
- [x] Build passes
- [ ] Test download flow: success, failure, network pause

Closes #52

@gemini-cli please review for critical issues only (crash risks, memory leaks, security vulnerabilities)

🤖 Generated with [Claude Code](https://claude.com/claude-code)