### PR TITLE
fix: prevent duplicate lifecycle callback registrations on recreate

### DIFF
--- a/app/src/main/java/com/lockit/ui/MainActivity.kt
+++ b/app/src/main/java/com/lockit/ui/MainActivity.kt
@@ -46,6 +46,11 @@ import kotlinx.coroutines.withContext
 
 class MainActivity : FragmentActivity() {
 
+    companion object {
+        // Flag to ensure lifecycle callbacks are registered only once
+        private var lifecycleCallbacksRegistered = false
+    }
+
     override fun attachBaseContext(newBase: Context) {
         super.attachBaseContext(LocaleHelper.applyLocale(newBase))
     }
@@ -59,28 +64,32 @@ class MainActivity : FragmentActivity() {
         // Invalidate biometric session and lock vault when app goes to background.
         // Note: isChangingConfigurations is true during recreate (e.g., language change),
         // we should NOT lock vault in that case.
-        (application as Application).registerActivityLifecycleCallbacks(
-            object : android.app.Application.ActivityLifecycleCallbacks {
-                private var startedActivities = 0
-                override fun onActivityStarted(activity: android.app.Activity) {
-                    startedActivities++
-                }
-                override fun onActivityStopped(activity: android.app.Activity) {
-                    startedActivities--
-                    // Skip locking if activity is recreating (language/theme change)
-                    if (startedActivities <= 0 && !activity.isChangingConfigurations) {
-                        BiometricUtils.invalidateSession()
-                        // Lock vault immediately when app goes to background
-                        app.vaultManager.lockVault()
+        // Only register callbacks ONCE to avoid duplicate registrations on recreate.
+        if (!lifecycleCallbacksRegistered) {
+            lifecycleCallbacksRegistered = true
+            (application as Application).registerActivityLifecycleCallbacks(
+                object : android.app.Application.ActivityLifecycleCallbacks {
+                    private var startedActivities = 0
+                    override fun onActivityStarted(activity: android.app.Activity) {
+                        startedActivities++
                     }
+                    override fun onActivityStopped(activity: android.app.Activity) {
+                        startedActivities--
+                        // Skip locking if activity is recreating (language/theme change)
+                        if (startedActivities <= 0 && !activity.isChangingConfigurations) {
+                            BiometricUtils.invalidateSession()
+                            // Lock vault immediately when app goes to background
+                            app.vaultManager.lockVault()
+                        }
+                    }
+                    override fun onActivityCreated(activity: android.app.Activity, savedInstanceState: Bundle?) {}
+                    override fun onActivityResumed(activity: android.app.Activity) {}
+                    override fun onActivityPaused(activity: android.app.Activity) {}
+                    override fun onActivitySaveInstanceState(activity: android.app.Activity, outState: Bundle) {}
+                    override fun onActivityDestroyed(activity: android.app.Activity) {}
                 }
-                override fun onActivityCreated(activity: android.app.Activity, savedInstanceState: Bundle?) {}
-                override fun onActivityResumed(activity: android.app.Activity) {}
-                override fun onActivityPaused(activity: android.app.Activity) {}
-                override fun onActivitySaveInstanceState(activity: android.app.Activity, outState: Bundle) {}
-                override fun onActivityDestroyed(activity: android.app.Activity) {}
-            }
-        )
+            )
+        }
 
         setContent {
             val themeMode = ThemePreference.getThemeMode(this)


### PR DESCRIPTION
## Summary
- Fixed language/theme switching incorrectly requiring password verification
- Root cause: ActivityLifecycleCallbacks were registered every onCreate, including recreation
- Each registration created new startedActivities counter, causing duplicate callbacks

## Changes
- Added companion object flag `lifecycleCallbacksRegistered` to ensure callbacks register only once
- This prevents duplicate callback objects accumulating on each activity recreate

## Test plan
- [x] Build passes
- [x] Lint passes
- [x] Manual testing: switch language without password prompt

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)