### PR TITLE
fix: proper back navigation from credential modal in Repos screen

### DIFF
--- a/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
@@ -348,7 +348,6 @@ fun ReposScreen(
     val revealedEmailPasswordMap = remember { mutableMapOf<String, String?>() }
     val revealedCredentialIds = remember { mutableStateListOf<String>() }
     var reposToastMessage by remember { mutableStateOf<String?>(null) }
-    var pendingCredentialForPinVerify by remember { mutableStateOf<Credential?>(null) }
 
     LaunchedEffect(selectedService) {
         viewModel.selectService(selectedService)
@@ -465,13 +464,33 @@ fun ReposScreen(
             }
 
             var selectedCredential by remember { mutableStateOf<Credential?>(null) }
+            var pendingCredentialForPinVerify by remember { mutableStateOf<Credential?>(null) }
 
-            // Handle Android back button: modal first, then service detail
-            BackHandler(enabled = selectedCredential != null) {
-                selectedCredential = null  // Close modal first
+            // Handle Android back button: PIN dialog → modal → service detail
+            BackHandler(enabled = pendingCredentialForPinVerify != null) {
+                pendingCredentialForPinVerify = null  // Close PIN dialog first
             }
-            BackHandler(enabled = selectedCredential == null) {
-                onServiceSelected(null)  // Go back to service list (when modal is closed)
+            BackHandler(enabled = selectedCredential != null && pendingCredentialForPinVerify == null) {
+                selectedCredential = null  // Close modal
+                revealedCredentialIds.clear()
+                revealedEmailPasswordMap.clear()
+            }
+            BackHandler(enabled = selectedCredential == null && pendingCredentialForPinVerify == null) {
+                onServiceSelected(null)  // Go back to service list
+                revealedCredentialIds.clear()
+                revealedEmailPasswordMap.clear()
+            }
+
+            // PIN verification dialog
+            pendingCredentialForPinVerify?.let { credential ->
+                BrutalistPinVerifyDialog(
+                    app = app,
+                    onVerified = {
+                        pendingCredentialForPinVerify = null
+                        selectedCredential = credential
+                    },
+                    onDismiss = { pendingCredentialForPinVerify = null },
+                )
             }
 
             if (selectedCredential != null) {
@@ -506,17 +525,6 @@ fun ReposScreen(
                     onNeedReveal = { },
                     isRevealed = true,
                     onHide = { },
-                )
-            }
-
-            pendingCredentialForPinVerify?.let { credential ->
-                BrutalistPinVerifyDialog(
-                    app = app,
-                    onVerified = {
-                        pendingCredentialForPinVerify = null
-                        selectedCredential = credential
-                    },
-                    onDismiss = { pendingCredentialForPinVerify = null },
                 )
             }
 

--- a/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
@@ -259,10 +259,6 @@ fun ReposScreen(
     val serviceCount = servicesByGroup.size
     val credentialCount = credentialList.size
 
-    // Handle Android back button when viewing a service's credentials
-    BackHandler(enabled = selectedService != null) {
-        onServiceSelected(null)
-    }
     var searchQuery by remember { mutableStateOf("") }
     val clipboardManager = LocalClipboardManager.current
     val context = LocalContext.current
@@ -469,6 +465,14 @@ fun ReposScreen(
             }
 
             var selectedCredential by remember { mutableStateOf<Credential?>(null) }
+
+            // Handle Android back button: modal first, then service detail
+            BackHandler(enabled = selectedCredential != null) {
+                selectedCredential = null  // Close modal first
+            }
+            BackHandler(enabled = selectedCredential == null) {
+                onServiceSelected(null)  // Go back to service list (when modal is closed)
+            }
 
             if (selectedCredential != null) {
                 CredentialCardModal(


### PR DESCRIPTION
## Summary
- Fixed back navigation in Repos screen to properly handle modal and service detail states
- Root cause: single BackHandler didn't distinguish between modal open and service detail view

## Changes
- Added two BackHandlers with priority:
  1. When modal open → close modal first
  2. When modal closed in service detail → go back to service list

## Test plan
- [x] Build passes
- [x] Lint passes
- [ ] Manual testing: Repos → service → credential → back → modal closes → back → service list

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)