### PR TITLE
fix: clear PIN input when lock screen is shown after manual lock

### DIFF
--- a/app/src/main/java/com/lockit/ui/screens/vault_unlock/VaultUnlockScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/vault_unlock/VaultUnlockScreen.kt
@@ -260,8 +260,8 @@ fun VaultUnlockScreen(
     val view = LocalView.current
     val colorScheme = MaterialTheme.colorScheme
 
-    // Clear PIN when screen is shown (e.g., after manual lock from Config)
-    LaunchedEffect(Unit) {
+    // Clear PIN whenever screen is shown (key = isVaultLocked to re-trigger after lock)
+    LaunchedEffect(app.vaultManager.isUnlocked()) {
         viewModel.setAppState(app.vaultManager.isInitialized())
         viewModel.clearPin()  // Ensure PIN is empty when lock screen is shown
     }


### PR DESCRIPTION
## Summary
- Fixed PIN input being pre-filled after locking from Config screen
- Root cause: LaunchedEffect(Unit) only runs once, not on recompose

## Changes
- Changed `LaunchedEffect(Unit)` to `LaunchedEffect(isVaultUnlocked())`
- This re-triggers clearPin() whenever vault state changes

## Test plan
- [x] Build passes
- [x] Lint passes
- [ ] Manual: Config → Lock Vault → PIN input should be empty

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)