### PR TITLE
fix: correct ConfigSection divider alignment

### DIFF
--- a/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
@@ -1005,7 +1005,7 @@ private fun ConfigSection(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(bottom = 8.dp),
-            verticalAlignment = Alignment.Bottom,
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
                 text = title,
@@ -1019,7 +1019,7 @@ private fun ConfigSection(
             Box(
                 modifier = Modifier
                     .height(1.dp)
-                    .fillMaxWidth()
+                    .weight(1f)
                     .background(Primary),
             )
         }


### PR DESCRIPTION
## Summary
- Fixed divider alignment in ConfigSection component
- Root cause: fillMaxWidth() inside Row doesn't fill remaining space properly

## Changes
- Use weight(1f) instead of fillMaxWidth() for proper space filling
- Change alignment from Bottom to CenterVertically for 1dp divider line

## Test plan
- [x] Build passes
- [x] Lint passes
- [ ] Manual: check Config page dividers extend properly from titles

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)