### PR TITLE
fix: add release workflow to upload APK to Release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,15 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
 
-    - name: Build Release APK
-      run: ./gradlew assembleRelease
+    # NOTE: Using debug APK for now. For production releases,
+    # set up proper signing with GitHub secrets:
+    # - KEYSTORE_BASE64 (base64 encoded keystore file)
+    # - KEYSTORE_PASSWORD
+    # - KEY_ALIAS
+    # - KEY_PASSWORD
+    # Then decode keystore and configure signing in build.gradle.kts
+    - name: Build Debug APK
+      run: ./gradlew assembleDebug
 
     - name: Upload APK to Release
       uses: softprops/action-gh-release@v2
@@ -36,5 +43,5 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        files: app/build/outputs/apk/release/app-release.apk
+        files: app/build/outputs/apk/debug/app-debug.apk
         fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release Build
+
+on:
+  release:
+    types: [created]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Build Debug APK
+      run: ./gradlew assembleDebug
+
+    - name: Upload APK to Release
+      uses: softprops/action-gh-release@v2
+      if: success()
+      with:
+        files: app/build/outputs/apk/debug/app-debug.apk
+        fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,14 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
 
-    - name: Build Debug APK
-      run: ./gradlew assembleDebug
+    - name: Build Release APK
+      run: ./gradlew assembleRelease
 
     - name: Upload APK to Release
       uses: softprops/action-gh-release@v2
       if: success()
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        files: app/build/outputs/apk/debug/app-debug.apk
+        files: app/build/outputs/apk/release/app-release.apk
         fail_on_unmatched_files: true


### PR DESCRIPTION
## Summary
- Add new release.yml workflow triggered on `release: created` event
- Build debug APK and upload to Release assets using `softprops/action-gh-release`
- Fixes issue where APKs were only uploaded to Actions artifacts (90-day expiry)

## Changes
- `.github/workflows/release.yml` — new workflow for release APK upload

## Test plan
- [ ] Workflow triggers on new release creation
- [ ] APK appears in Release assets
- [ ] APK downloadable from Release page

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)