### PR TITLE
feat: 5-minute background lock delay with immediate lock on cold start

### DIFF
--- a/app/src/main/java/com/lockit/ui/MainActivity.kt
+++ b/app/src/main/java/com/lockit/ui/MainActivity.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import com.lockit.LockitApp
 import com.lockit.ui.components.BottomNavItem
 import com.lockit.ui.components.BrutalistBottomNav
@@ -49,6 +50,11 @@ class MainActivity : FragmentActivity() {
     companion object {
         // Flag to ensure lifecycle callbacks are registered only once
         private var lifecycleCallbacksRegistered = false
+        // SharedPreferences key for background timestamp
+        const val PREFS_NAME = "lockit_background_prefs"
+        const val KEY_BACKGROUND_TIMESTAMP = "background_timestamp"
+        // 5 minutes in milliseconds
+        const val BACKGROUND_LOCK_DELAY_MS = 5 * 60 * 1000L
     }
 
     override fun attachBaseContext(newBase: Context) {
@@ -60,6 +66,17 @@ class MainActivity : FragmentActivity() {
         enableEdgeToEdge()
 
         val app = application as LockitApp
+
+        // On cold start: if there's a background timestamp, lock immediately
+        // (Process was killed while in background → require immediate authentication)
+        val bgPrefs = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val bgTimestamp = bgPrefs.getLong(KEY_BACKGROUND_TIMESTAMP, 0)
+        if (bgTimestamp > 0) {
+            // Clear timestamp immediately to prevent repeated locks
+            bgPrefs.edit().remove(KEY_BACKGROUND_TIMESTAMP).apply()
+            // Lock vault - process was killed while in background
+            app.vaultManager.lockVault()
+        }
 
         // Invalidate biometric session and lock vault when app goes to background.
         // Note: isChangingConfigurations is true during recreate (e.g., language change),
@@ -75,11 +92,13 @@ class MainActivity : FragmentActivity() {
                     }
                     override fun onActivityStopped(activity: android.app.Activity) {
                         startedActivities--
-                        // Skip locking if activity is recreating (language/theme change)
+                        // Skip if activity is recreating (language/theme change)
                         if (startedActivities <= 0 && !activity.isChangingConfigurations) {
                             BiometricUtils.invalidateSession()
-                            // Lock vault immediately when app goes to background
-                            app.vaultManager.lockVault()
+                            // Record background timestamp instead of immediate lock
+                            // On cold start after process kill, will lock immediately
+                            val prefs = activity.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                            prefs.edit().putLong(KEY_BACKGROUND_TIMESTAMP, System.currentTimeMillis()).apply()
                         }
                     }
                     override fun onActivityCreated(activity: android.app.Activity, savedInstanceState: Bundle?) {}
@@ -115,11 +134,24 @@ private fun MainFlow(app: LockitApp) {
     var isVaultUnlocked by remember { mutableStateOf(app.vaultManager.isUnlocked()) }
     val scope = rememberCoroutineScope()
     val lifecycleOwner = LocalLifecycleOwner.current
+    val context = LocalContext.current
 
     // Observe lifecycle to update vault state when app returns from background
     androidx.compose.runtime.DisposableEffect(lifecycleOwner) {
         val observer = object : DefaultLifecycleObserver {
             override fun onResume(owner: LifecycleOwner) {
+                // Check background timestamp: lock if > 5 minutes passed
+                val bgPrefs = context.getSharedPreferences(MainActivity.PREFS_NAME, Context.MODE_PRIVATE)
+                val bgTimestamp = bgPrefs.getLong(MainActivity.KEY_BACKGROUND_TIMESTAMP, 0)
+                if (bgTimestamp > 0) {
+                    val elapsed = System.currentTimeMillis() - bgTimestamp
+                    if (elapsed > MainActivity.BACKGROUND_LOCK_DELAY_MS) {
+                        // More than 5 minutes: lock vault
+                        app.vaultManager.lockVault()
+                    }
+                    // Clear timestamp (app is now in foreground)
+                    bgPrefs.edit().remove(MainActivity.KEY_BACKGROUND_TIMESTAMP).apply()
+                }
                 // Check if vault was locked while app was in background
                 isVaultUnlocked = app.vaultManager.isUnlocked()
             }

--- a/app/src/main/java/com/lockit/ui/MainActivity.kt
+++ b/app/src/main/java/com/lockit/ui/MainActivity.kt
@@ -99,7 +99,8 @@ class MainActivity : FragmentActivity() {
                             // Record background timestamp instead of immediate lock
                             // On cold start after process kill, will lock immediately
                             val prefs = activity.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-                            prefs.edit().putLong(KEY_BACKGROUND_TIMESTAMP, System.currentTimeMillis()).apply()
+                            // Use commit() for synchronous write - security-critical
+                            prefs.edit().putLong(KEY_BACKGROUND_TIMESTAMP, System.currentTimeMillis()).commit()
                         }
                     }
                     override fun onActivityCreated(activity: android.app.Activity, savedInstanceState: Bundle?) {}

--- a/app/src/main/java/com/lockit/ui/MainActivity.kt
+++ b/app/src/main/java/com/lockit/ui/MainActivity.kt
@@ -74,14 +74,16 @@ class MainActivity : FragmentActivity() {
         if (bgTimestamp > 0) {
             // Clear timestamp immediately to prevent repeated locks
             bgPrefs.edit().remove(KEY_BACKGROUND_TIMESTAMP).apply()
-            // Lock vault - process was killed while in background
+            // Lock vault and invalidate session - process was killed while in background
             app.vaultManager.lockVault()
+            BiometricUtils.invalidateSession()
         }
 
-        // Invalidate biometric session and lock vault when app goes to background.
+        // Record background timestamp when app goes to background.
+        // On resume: if > 5 minutes passed, lock vault and invalidate session.
+        // On cold start: if timestamp exists, lock immediately (process was killed).
         // Note: isChangingConfigurations is true during recreate (e.g., language change),
-        // we should NOT lock vault in that case.
-        // Only register callbacks ONCE to avoid duplicate registrations on recreate.
+        // we should NOT record timestamp in that case.
         if (!lifecycleCallbacksRegistered) {
             lifecycleCallbacksRegistered = true
             (application as Application).registerActivityLifecycleCallbacks(
@@ -94,7 +96,6 @@ class MainActivity : FragmentActivity() {
                         startedActivities--
                         // Skip if activity is recreating (language/theme change)
                         if (startedActivities <= 0 && !activity.isChangingConfigurations) {
-                            BiometricUtils.invalidateSession()
                             // Record background timestamp instead of immediate lock
                             // On cold start after process kill, will lock immediately
                             val prefs = activity.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -146,8 +147,9 @@ private fun MainFlow(app: LockitApp) {
                 if (bgTimestamp > 0) {
                     val elapsed = System.currentTimeMillis() - bgTimestamp
                     if (elapsed > MainActivity.BACKGROUND_LOCK_DELAY_MS) {
-                        // More than 5 minutes: lock vault
+                        // More than 5 minutes: lock vault and invalidate session
                         app.vaultManager.lockVault()
+                        BiometricUtils.invalidateSession()
                     }
                     // Clear timestamp (app is now in foreground)
                     bgPrefs.edit().remove(MainActivity.KEY_BACKGROUND_TIMESTAMP).apply()


### PR DESCRIPTION
## Summary
- Add 5-minute grace period before locking vault when app goes to background
- Lock vault immediately on cold start if process was killed while in background

## Changes
- Record background timestamp in SharedPreferences when app goes to background
- On resume: check elapsed time, lock if > 5 minutes passed
- On cold start: if timestamp exists, lock immediately (process was killed)

## Behavior
- Home key/background: 5 minute grace period before lock
- Process kill/swipe close: immediate lock on next open

## Test plan
- [ ] Press Home, return within 5 minutes → vault still unlocked
- [ ] Press Home, return after 5 minutes → vault locked, require PIN
- [ ] Kill app process, reopen → vault locked immediately

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)