### PR TITLE
fix: use rememberSaveable to persist navigation state across Activity recreation

### DIFF
--- a/app/src/main/java/com/lockit/ui/MainActivity.kt
+++ b/app/src/main/java/com/lockit/ui/MainActivity.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -210,12 +211,12 @@ private fun MainFlow(app: LockitApp) {
         return
     }
 
-    var currentScreen by remember { mutableStateOf(AppScreen.Repos) }
-    var selectedCredentialId by remember { mutableStateOf<String?>(null) }
-    var editingCredentialId by remember { mutableStateOf<String?>(null) }
-    var reposSelectedService by remember { mutableStateOf<String?>(null) }
+    var currentScreen by rememberSaveable { mutableStateOf(AppScreen.Repos) }
+    var selectedCredentialId by rememberSaveable { mutableStateOf<String?>(null) }
+    var editingCredentialId by rememberSaveable { mutableStateOf<String?>(null) }
+    var reposSelectedService by rememberSaveable { mutableStateOf<String?>(null) }
     // Track previous screen for proper back navigation
-    var previousScreen by remember { mutableStateOf(AppScreen.VaultExplorer) }
+    var previousScreen by rememberSaveable { mutableStateOf(AppScreen.VaultExplorer) }
 
     LaunchedEffect(currentScreen) {
         if (currentScreen != AppScreen.SecretDetails) {


### PR DESCRIPTION
## Summary
- Use rememberSaveable instead of remember for navigation state variables
- Persists currentScreen, selectedCredentialId, reposSelectedService across Activity recreation
- Fixes theme/language switch causing unexpected navigation to Repos page

## Changes
- `MainActivity.kt`: Changed remember → rememberSaveable for state variables

## Test plan
- [ ] Go to Config screen, change theme → stay on Config screen
- [ ] Go to VaultExplorer, change language → stay on VaultExplorer

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)