### PR TITLE
fix: use theme-aware backgrounds for dark mode support

### DIFF
--- a/app/src/main/java/com/lockit/ui/screens/add_credential/AddCredentialScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/add_credential/AddCredentialScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
@@ -317,7 +318,7 @@ fun AddCredentialScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(White),
+            .background(MaterialTheme.colorScheme.surface),
     ) {
         BrutalistTopBar(showBackButton = false)
 

--- a/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
@@ -225,7 +225,7 @@ fun ConfigScreen(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .background(White),
+            .background(MaterialTheme.colorScheme.surface),
     ) {
         BrutalistTopBar()
 
@@ -736,8 +736,8 @@ private fun ChangePasswordDialog(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(White)
-                .border(2.dp, Color.Black)
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                .border(2.dp, MaterialTheme.colorScheme.primary)
                 .padding(24.dp),
         ) {
             Text(
@@ -1067,8 +1067,8 @@ private fun UpdateDialog(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(White)
-                .border(2.dp, Color.Black)
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                .border(2.dp, MaterialTheme.colorScheme.primary)
                 .padding(24.dp),
         ) {
             Text(
@@ -1160,8 +1160,8 @@ private fun GitHubTokenConfigDialog(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(White)
-                .border(2.dp, Color.Black)
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                .border(2.dp, MaterialTheme.colorScheme.primary)
                 .padding(24.dp),
         ) {
             Text(

--- a/app/src/main/java/com/lockit/ui/screens/edit_credential/EditCredentialScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/edit_credential/EditCredentialScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -69,7 +70,7 @@ fun EditCredentialScreen(
 
     if (isLoading) {
         Box(
-            modifier = Modifier.fillMaxSize().background(White),
+            modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.surface),
             contentAlignment = Alignment.Center,
         ) {
             Text(
@@ -84,7 +85,7 @@ fun EditCredentialScreen(
 
     val cred = credential ?: run {
         Box(
-            modifier = Modifier.fillMaxSize().background(White),
+            modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.surface),
             contentAlignment = Alignment.Center,
         ) {
             Text(
@@ -239,7 +240,7 @@ private fun EditCredentialForm(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(White),
+            .background(MaterialTheme.colorScheme.surface),
     ) {
         BrutalistTopBar(showBackButton = false)
 

--- a/app/src/main/java/com/lockit/ui/screens/logs/LogsScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/logs/LogsScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.LockOpen
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -68,7 +69,7 @@ fun LogsScreen(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .background(White),
+            .background(MaterialTheme.colorScheme.surface),
     ) {
         BrutalistTopBar()
 

--- a/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CloudUpload
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import com.lockit.ui.components.BrutalistTextField
 import com.lockit.ui.components.CopyAction
@@ -361,7 +362,7 @@ fun ReposScreen(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .background(White),
+            .background(MaterialTheme.colorScheme.surface),
     ) {
         BrutalistTopBar()
 
@@ -867,7 +868,7 @@ internal fun CredentialCardModal(
         Column(
             modifier = Modifier
                 .fillMaxWidth(0.9f)
-                .background(White)
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh)
                 .clickable(enabled = false) {},
         ) {
             CredentialCard(

--- a/app/src/main/java/com/lockit/ui/screens/secret_details/SecretDetailsScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/secret_details/SecretDetailsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -121,7 +122,7 @@ fun SecretDetailsScreen(
 
     if (isLoading) {
         Box(
-            modifier = Modifier.fillMaxSize().background(White),
+            modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.surface),
             contentAlignment = Alignment.Center,
         ) {
             Text(
@@ -137,7 +138,7 @@ fun SecretDetailsScreen(
     val cred = credential
     if (cred == null) {
         Box(
-            modifier = Modifier.fillMaxSize().background(White),
+            modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.surface),
             contentAlignment = Alignment.Center,
         ) {
             Column(horizontalAlignment = Alignment.CenterHorizontally) {

--- a/app/src/main/java/com/lockit/ui/screens/vault_explorer/VaultExplorerScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/vault_explorer/VaultExplorerScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
@@ -227,7 +228,7 @@ fun VaultExplorerScreen(
         }
     }
 
-    Column(modifier = Modifier.fillMaxSize().background(White)) {
+    Column(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.surface)) {
         BrutalistTopBar(
             rightContent = {
                 TopBarAddButton(onClick = onNavigateToAdd)

--- a/app/src/main/java/com/lockit/ui/screens/vault_unlock/VaultUnlockScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/vault_unlock/VaultUnlockScreen.kt
@@ -520,8 +520,8 @@ fun VaultUnlockScreen(
                 Column(
                     modifier = Modifier
                         .fillMaxWidth(0.85f)
-                        .background(White)
-                        .border(2.dp, Primary)
+                        .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                        .border(2.dp, MaterialTheme.colorScheme.primary)
                         .padding(20.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {


### PR DESCRIPTION
## Summary
- Replace hardcoded White backgrounds with MaterialTheme.colorScheme.surface
- Ensures proper dark mode support across all screens
- Dialogs/modals use surfaceContainerHigh for elevated appearance

## Changes
- VaultExplorerScreen, ConfigScreen, ReposScreen, LogsScreen
- AddCredentialScreen, EditCredentialScreen, SecretDetailsScreen
- VaultUnlockScreen biometric dialog

## Test plan
- [ ] Light mode: screens display correctly with white backgrounds
- [ ] Dark mode: screens display correctly with dark backgrounds (#131313)
- [ ] Dialogs appear elevated in both modes

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)