### PR TITLE
fix: right-align timestamp in CredentialCard footer

### DIFF
--- a/app/src/main/java/com/lockit/ui/components/CredentialCard.kt
+++ b/app/src/main/java/com/lockit/ui/components/CredentialCard.kt
@@ -633,16 +633,21 @@ private fun CardFooter(credential: Credential) {
             InfoTag(text = credential.type.displayName)
         }
         Spacer(modifier = Modifier.height(4.dp))
-        // Timestamp row - separate line to prevent overlap
-        Text(
-            text = "Secure // ${credential.formatUpdatedAt()}",
-            fontFamily = JetBrainsMonoFamily,
-            fontSize = 10.sp,
-            color = IndustrialOrange,
-            fontWeight = FontWeight.Bold,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
+        // Timestamp row - right aligned to match card's visual style
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End,
+        ) {
+            Text(
+                text = "Secure // ${credential.formatUpdatedAt()}",
+                fontFamily = JetBrainsMonoFamily,
+                fontSize = 10.sp,
+                color = IndustrialOrange,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Changed timestamp row to use Arrangement.End for right alignment
- Matches card's visual style where other metadata is right-aligned

## Changes
- CredentialCard.kt: CardFooter uses Row with Arrangement.End

## Test plan
- [ ] CredentialCard displays timestamp right-aligned at bottom

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)