### PR TITLE
fix: restore navigation state after vault unlock

### DIFF
--- a/app/src/main/java/com/lockit/ui/MainActivity.kt
+++ b/app/src/main/java/com/lockit/ui/MainActivity.kt
@@ -134,6 +134,14 @@ enum class AppScreen {
 
 @androidx.compose.runtime.Composable
 private fun MainFlow(app: LockitApp) {
+    // Navigation state - must be declared BEFORE vault unlock check
+    // so they survive the vault lock/unlock cycle
+    var currentScreen by rememberSaveable { mutableStateOf(AppScreen.Repos) }
+    var selectedCredentialId by rememberSaveable { mutableStateOf<String?>(null) }
+    var editingCredentialId by rememberSaveable { mutableStateOf<String?>(null) }
+    var reposSelectedService by rememberSaveable { mutableStateOf<String?>(null) }
+    var previousScreen by rememberSaveable { mutableStateOf(AppScreen.VaultExplorer) }
+
     var isVaultUnlocked by remember { mutableStateOf(app.vaultManager.isUnlocked()) }
     val scope = rememberCoroutineScope()
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -211,13 +219,7 @@ private fun MainFlow(app: LockitApp) {
         return
     }
 
-    var currentScreen by rememberSaveable { mutableStateOf(AppScreen.Repos) }
-    var selectedCredentialId by rememberSaveable { mutableStateOf<String?>(null) }
-    var editingCredentialId by rememberSaveable { mutableStateOf<String?>(null) }
-    var reposSelectedService by rememberSaveable { mutableStateOf<String?>(null) }
-    // Track previous screen for proper back navigation
-    var previousScreen by rememberSaveable { mutableStateOf(AppScreen.VaultExplorer) }
-
+    // Navigation state already declared before vault check
     LaunchedEffect(currentScreen) {
         if (currentScreen != AppScreen.SecretDetails) {
             selectedCredentialId = null


### PR DESCRIPTION
## Summary
- Move navigation state variables to be declared BEFORE vault unlock check
- Ensures `currentScreen`, `selectedCredentialId`, etc. remain in composition tree during lock/unlock cycle
- User returns to previous page after unlocking instead of home page

## Changes
- `MainActivity.kt`: Moved `rememberSaveable` navigation state declarations before `isVaultUnlocked` check

## Root cause
Navigation state variables were declared AFTER the vault unlock check. When vault locked, VaultUnlockScreen rendered and these variables weren't in composition tree. After unlock, they reinitialized with default values (Repos screen).

## Test plan
- [x] Build passes
- [x] Lint passes
- [ ] Manual test: Navigate to a screen, trigger vault lock, unlock → should return to same screen

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)