### PR TITLE
fix: display ACCOUNT before TOKEN in GitHub card + v0.1.9

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.lockit"
         minSdk = 26
         targetSdk = 35
-        versionCode = 1008
-        versionName = "0.1.8"
+        versionCode = 1009
+        versionName = "0.1.9"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/lockit/ui/components/CredentialCard.kt
+++ b/app/src/main/java/com/lockit/ui/components/CredentialCard.kt
@@ -503,12 +503,16 @@ private fun CredentialContent(
         }
 
         CredentialType.GitHub -> {
-            // GitHub: show TOKEN_VALUE with reveal toggle, plus NAME, ACCOUNT, TYPE, SCOPE
+            // GitHub: show ACCOUNT first, then TOKEN with reveal toggle, plus NAME, TYPE, SCOPE
             val name = fields.getNotBlank(0)
             val tokenType = fields.getNotBlank(1)
             val account = fields.getNotBlank(2)
             val tokenValue = fields.getNotBlank(3) ?: CredentialDefaults.FIELD_NOT_SET
             val scope = fields.getNotBlank(4)
+
+            // ACCOUNT - shown first at top
+            OptionalFieldRow("ACCOUNT", account)
+            if (account != null) Spacer(modifier = Modifier.height(8.dp))
 
             // TOKEN_VALUE - revealable
             RevealableValueBox(
@@ -523,9 +527,8 @@ private fun CredentialContent(
                 clipboardManager = clipboardManager,
             )
 
-            // Show optional fields with consistent spacing
+            // Show other optional fields with consistent spacing
             OptionalFieldRow("NAME", name, showIf = { it != credential.name })
-            OptionalFieldRow("ACCOUNT", account)
             OptionalFieldRow("TYPE", tokenType)
             OptionalFieldRow("SCOPE", scope)
         }


### PR DESCRIPTION
## Summary
- Reorder GitHub credential card: ACCOUNT field displayed at top before TOKEN
- Update version to 0.1.9 (versionCode 1009)

## Changes
- `CredentialCard.kt`: ACCOUNT shown first, TOKEN with reveal toggle below
- `build.gradle.kts`: version bump to 0.1.9

## Test plan
- [x] Build passes
- [ ] Verify GitHub card shows ACCOUNT before TOKEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)