### PR TITLE
fix: display BASE_URL before API_KEY in CodingPlan card + v0.2.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.lockit"
         minSdk = 26
         targetSdk = 35
-        versionCode = 1009
-        versionName = "0.1.9"
+        versionCode = 1010
+        versionName = "0.2.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/lockit/ui/components/CredentialCard.kt
+++ b/app/src/main/java/com/lockit/ui/components/CredentialCard.kt
@@ -452,26 +452,11 @@ private fun CredentialContent(
         }
 
         CredentialType.CodingPlan -> {
-            // CodingPlan: API_KEY + BASE_URL
+            // CodingPlan: BASE_URL first, then API_KEY below
             val apiKey = fields.getNotBlank(2) ?: CredentialDefaults.FIELD_NOT_SET
             val baseUrl = fields.getNotBlank(5) ?: CredentialDefaults.FIELD_NOT_SET
 
-            // API_KEY - revealable
-            RevealableValueBox(
-                label = "API_KEY",
-                value = apiKey,
-                isRevealed = isRevealed,
-                maskPlaceholder = maskPlaceholder,
-                maxLinesRevealed = 3,
-                onNeedReveal = onNeedReveal,
-                onHide = onHide,
-                onCopy = { onCopy(CopyAction.API_KEY) },
-                clipboardManager = clipboardManager,
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            // BASE_URL - always visible
+            // BASE_URL - always visible, shown first at top
             FieldLabel("BASE_URL")
             Spacer(modifier = Modifier.height(4.dp))
             Box(
@@ -500,6 +485,21 @@ private fun CredentialContent(
                     overflow = TextOverflow.Ellipsis,
                 )
             }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // API_KEY - revealable
+            RevealableValueBox(
+                label = "API_KEY",
+                value = apiKey,
+                isRevealed = isRevealed,
+                maskPlaceholder = maskPlaceholder,
+                maxLinesRevealed = 3,
+                onNeedReveal = onNeedReveal,
+                onHide = onHide,
+                onCopy = { onCopy(CopyAction.API_KEY) },
+                clipboardManager = clipboardManager,
+            )
         }
 
         CredentialType.GitHub -> {


### PR DESCRIPTION
## Summary
- Reorder CodingPlan (Qwen-Bailian) card: BASE_URL now displayed before API_KEY
- Update version to 0.2.0

## Changes
- `CredentialCard.kt`: BASE_URL shown first, API_KEY with reveal toggle below
- `build.gradle.kts`: version bump to 0.2.0

## Test plan
- [x] Build passes
- [ ] Verify CodingPlan card shows BASE_URL before API_KEY

🤖 Generated with [Claude Code](https://claude.com/claude-code)