### PR TITLE
fix: improve download update diagnostic messages

### DIFF
--- a/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
@@ -5,6 +5,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import com.google.android.gms.auth.api.signin.GoogleSignIn
@@ -695,12 +696,25 @@ fun ConfigScreen(
                                         ?.find { it.name == githubTokenCredentialName }
 
                                     // Token is optional - public repos work without it
-                                    // Private repos or rate limit bypass require token
+                                    // Show diagnostic toast if configured token has issues (non-blocking)
+                                    var tokenDiagnostic: String? = null
                                     val token: String? = if (tokenCredential != null) {
                                         val fields = tokenCredential.value?.let { parseCredentialFields(it) }
-                                        fields?.getOrNull(3)?.takeIf { it.isNotBlank() }
+                                        val parsedToken = fields?.getOrNull(3)?.takeIf { it.isNotBlank() }
+                                        if (parsedToken == null) {
+                                            // Credential exists but token field is empty/blank
+                                            tokenDiagnostic = context.getString(R.string.toast_token_empty)
+                                        }
+                                        parsedToken
                                     } else {
-                                        null // No token stored - proceed without it for public repo
+                                        // Token credential not found in vault
+                                        tokenDiagnostic = context.getString(R.string.toast_token_not_found)
+                                        null
+                                    }
+
+                                    // Show diagnostic toast if token has issues (non-blocking, just info)
+                                    if (tokenDiagnostic != null) {
+                                        Toast.makeText(context, tokenDiagnostic, Toast.LENGTH_SHORT).show()
                                     }
 
                                     lastCheckedToken = token // Store for download (null if public repo)

--- a/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
@@ -720,11 +720,12 @@ fun ConfigScreen(
                                         val errorMsg = result.exceptionOrNull()?.message ?: "Unknown error"
                                         // AppUpdater returns descriptive messages for common errors:
                                         // - 403: "GitHub API rate limit exceeded..."
-                                        // - 404: "Release not found"
+                                        // - 404: "Release not found" (could mean private repo permission issue if token used)
                                         // - Other HTTP codes: "HTTP X"
+                                        // Since we only reach here with a valid token, 404 likely means permission issue
                                         val detailedMessage = when {
                                             errorMsg.contains("rate limit", ignoreCase = true) -> context.getString(R.string.toast_rate_limit)
-                                            errorMsg.contains("Release not found", ignoreCase = true) -> context.getString(R.string.toast_release_not_found)
+                                            errorMsg.contains("Release not found", ignoreCase = true) -> "${context.getString(R.string.toast_private_repo_denied)} (Token needs 'repo' scope)"
                                             else -> "${context.getString(R.string.toast_check_failed)} $errorMsg"
                                         }
                                         toastMessage = detailedMessage

--- a/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
@@ -716,10 +716,12 @@ fun ConfigScreen(
                                     if (result.isFailure) {
                                         val errorMsg = result.exceptionOrNull()?.message ?: "Unknown error"
                                         // Provide specific guidance for common errors
+                                        // Note: AppUpdater returns descriptive messages, not numeric codes
                                         val detailedMessage = when {
-                                            errorMsg.contains("404") -> "${context.getString(R.string.toast_private_repo_denied)} (Token needs 'repo' scope)"
-                                            errorMsg.contains("403") -> "${context.getString(R.string.toast_rate_limit)}"
-                                            errorMsg.contains("Release not found") -> context.getString(R.string.toast_release_not_found)
+                                            errorMsg.contains("rate limit", ignoreCase = true) -> context.getString(R.string.toast_rate_limit)
+                                            errorMsg.contains("Release not found", ignoreCase = true) -> context.getString(R.string.toast_release_not_found)
+                                            errorMsg.contains("HTTP 404") -> "${context.getString(R.string.toast_private_repo_denied)} (Token needs 'repo' scope)"
+                                            errorMsg.contains("HTTP 403") -> context.getString(R.string.toast_rate_limit)
                                             else -> "${context.getString(R.string.toast_check_failed)} $errorMsg"
                                         }
                                         toastMessage = detailedMessage

--- a/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
@@ -680,16 +680,19 @@ fun ConfigScreen(
                             onClick = {
                                 isCheckingUpdate = true
                                 scope.launch {
-                                    // Check vault is unlocked before reading credentials
-                                    if (!app.vaultManager.isUnlocked()) {
+                                    // Wrap vault access in runCatching to handle race condition
+                                    // Vault could be locked between isUnlocked() check and Flow.first()
+                                    val credentialsResult = runCatching {
+                                        app.vaultManager.getAllCredentials().first()
+                                    }
+                                    if (credentialsResult.isFailure) {
                                         toastMessage = context.getString(R.string.toast_vault_locked)
                                         isCheckingUpdate = false
                                         return@launch
                                     }
                                     // Read GitHub Token from vault
-                                    val tokenCredential = app.vaultManager.getAllCredentials()
-                                        .first()
-                                        .find { it.name == githubTokenCredentialName }
+                                    val tokenCredential = credentialsResult.getOrNull()
+                                        ?.find { it.name == githubTokenCredentialName }
 
                                     // Diagnostic: Check if credential exists
                                     if (tokenCredential == null) {
@@ -903,9 +906,15 @@ private fun exportKeys(
 
     scope.launch(Dispatchers.IO) {
         try {
-            // Get all credentials synchronously (need to collect from Flow)
-            val credentials = app.vaultManager.getAllCredentials()
-                .first()
+            // Wrap in runCatching to handle race condition where vault gets locked
+            val credentialsResult = runCatching {
+                app.vaultManager.getAllCredentials().first()
+            }
+            if (credentialsResult.isFailure) {
+                callback(null, "Vault locked or inaccessible")
+                return@launch
+            }
+            val credentials = credentialsResult.getOrNull() ?: emptyList()
 
             val content = buildString {
                 appendLine("# Lockit Credentials Export")

--- a/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
@@ -718,13 +718,13 @@ fun ConfigScreen(
                                     isCheckingUpdate = false
                                     if (result.isFailure) {
                                         val errorMsg = result.exceptionOrNull()?.message ?: "Unknown error"
-                                        // Provide specific guidance for common errors
-                                        // Note: AppUpdater returns descriptive messages, not numeric codes
+                                        // AppUpdater returns descriptive messages for common errors:
+                                        // - 403: "GitHub API rate limit exceeded..."
+                                        // - 404: "Release not found"
+                                        // - Other HTTP codes: "HTTP X"
                                         val detailedMessage = when {
                                             errorMsg.contains("rate limit", ignoreCase = true) -> context.getString(R.string.toast_rate_limit)
                                             errorMsg.contains("Release not found", ignoreCase = true) -> context.getString(R.string.toast_release_not_found)
-                                            errorMsg.contains("HTTP 404") -> "${context.getString(R.string.toast_private_repo_denied)} (Token needs 'repo' scope)"
-                                            errorMsg.contains("HTTP 403") -> context.getString(R.string.toast_rate_limit)
                                             else -> "${context.getString(R.string.toast_check_failed)} $errorMsg"
                                         }
                                         toastMessage = detailedMessage
@@ -911,7 +911,9 @@ private fun exportKeys(
                 app.vaultManager.getAllCredentials().first()
             }
             if (credentialsResult.isFailure) {
-                callback(null, "Vault locked or inaccessible")
+                withContext(Dispatchers.Main) {
+                    callback(null, "Vault locked or inaccessible")
+                }
                 return@launch
             }
             val credentials = credentialsResult.getOrNull() ?: emptyList()

--- a/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
@@ -690,30 +690,20 @@ fun ConfigScreen(
                                         isCheckingUpdate = false
                                         return@launch
                                     }
-                                    // Read GitHub Token from vault
+                                    // Read GitHub Token from vault (optional - public repos don't need it)
                                     val tokenCredential = credentialsResult.getOrNull()
                                         ?.find { it.name == githubTokenCredentialName }
 
-                                    // Diagnostic: Check if credential exists
-                                    if (tokenCredential == null) {
-                                        toastMessage = "${context.getString(R.string.toast_token_not_found)}: $githubTokenCredentialName"
-                                        isCheckingUpdate = false
-                                        return@launch
+                                    // Token is optional - public repos work without it
+                                    // Private repos or rate limit bypass require token
+                                    val token: String? = if (tokenCredential != null) {
+                                        val fields = tokenCredential.value?.let { parseCredentialFields(it) }
+                                        fields?.getOrNull(3)?.takeIf { it.isNotBlank() }
+                                    } else {
+                                        null // No token stored - proceed without it for public repo
                                     }
 
-                                    // Parse combined value to extract TOKEN_VALUE (index 3)
-                                    // For GitHub/Token/ApiKey types, the secret is always at field index 3
-                                    val fields = tokenCredential.value?.let { parseCredentialFields(it) }
-                                    val token = fields?.getOrNull(3)?.takeIf { it.isNotBlank() }
-
-                                    // Diagnostic: Check if token is empty
-                                    if (token == null || token.isBlank()) {
-                                        toastMessage = context.getString(R.string.toast_token_empty)
-                                        isCheckingUpdate = false
-                                        return@launch
-                                    }
-
-                                    lastCheckedToken = token // Store for download
+                                    lastCheckedToken = token // Store for download (null if public repo)
                                     val result = appUpdater.checkForUpdate(currentVersionCode, token)
                                     isCheckingUpdate = false
                                     if (result.isFailure) {
@@ -725,7 +715,14 @@ fun ConfigScreen(
                                         // Since we only reach here with a valid token, 404 likely means permission issue
                                         val detailedMessage = when {
                                             errorMsg.contains("rate limit", ignoreCase = true) -> context.getString(R.string.toast_rate_limit)
-                                            errorMsg.contains("Release not found", ignoreCase = true) -> "${context.getString(R.string.toast_private_repo_denied)} (Token needs 'repo' scope)"
+                                            errorMsg.contains("Release not found", ignoreCase = true) -> {
+                                                // If token was used, likely permission issue; otherwise just no release
+                                                if (token != null) {
+                                                    "${context.getString(R.string.toast_private_repo_denied)} (Token needs 'repo' scope)"
+                                                } else {
+                                                    context.getString(R.string.toast_release_not_found)
+                                                }
+                                            }
                                             else -> "${context.getString(R.string.toast_check_failed)} $errorMsg"
                                         }
                                         toastMessage = detailedMessage


### PR DESCRIPTION
## Summary
- Add clear error when GitHub token credential not found in vault
- Add clear error when token value is empty  
- Add specific guidance for private repo access denied (needs 'repo' scope)
- Add Chinese translations for all new error messages
- Update footer version strings to v0.2.0

## Problem
用户报告下载更新功能失败，但之前的错误信息不够明确，无法帮助用户诊断根本原因。

## Solution
增加诊断性错误消息：
1. 凭证不存在 -> 提示创建 GITHUB_TOKEN 凭证
2. Token值为空 -> 提示Token字段为空
3. 私有仓库404 -> 提示Token需要 'repo' scope

## Changes
- `ConfigScreen.kt`: 改进更新检查逻辑，增加详细错误诊断
- `strings.xml`: 添加新错误消息的英文翻译
- `strings.xml (zh)`: 添加新错误消息的中文翻译

## Test plan
- [x] Build passes
- [x] Lint passes
- [ ] Manual testing: 创建/不创建 GITHUB_TOKEN 凭证测试各种错误场景

🤖 Generated with [Claude Code](https://claude.com/claude-code)