### PR TITLE
fix: bottom nav background + quota gauge percentage display

### DIFF
--- a/app/src/main/java/com/lockit/ui/components/BrutalistBottomNav.kt
+++ b/app/src/main/java/com/lockit/ui/components/BrutalistBottomNav.kt
@@ -3,6 +3,7 @@ package com.lockit.ui.components
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -29,6 +30,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.lockit.R
+import com.lockit.ui.theme.DarkSurface
 import com.lockit.ui.theme.JetBrainsMonoFamily
 import com.lockit.ui.theme.Primary
 import com.lockit.ui.theme.White
@@ -47,12 +49,15 @@ fun BrutalistBottomNav(
     modifier: Modifier = Modifier,
 ) {
     val colorScheme = MaterialTheme.colorScheme
-    // Use theme-aware colors
-    val backgroundColor = colorScheme.surface
-    val borderColor = colorScheme.primary
-    val selectedBgColor = colorScheme.primary
-    val selectedContentColor = colorScheme.onPrimary
-    val unselectedContentColor = colorScheme.onSurfaceVariant
+    // Explicitly use theme-aware background colors
+    // Light mode: White background with black border
+    // Dark mode: DarkSurface background with white border
+    val isDarkTheme = isSystemInDarkTheme()
+    val backgroundColor = if (isDarkTheme) DarkSurface else White
+    val borderColor = if (isDarkTheme) Color.White else Primary
+    val selectedBgColor = if (isDarkTheme) Color.White else Primary
+    val selectedContentColor = if (isDarkTheme) Color(0xFF410000) else White  // Dark red on white / White on black
+    val unselectedContentColor = if (isDarkTheme) Color.White.copy(alpha = 0.7f) else Color(0xFF666666)
 
     Row(
         modifier = modifier

--- a/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
@@ -1103,22 +1103,26 @@ private fun QuotaGauge(label: String, used: Int, total: Int, modifier: Modifier 
         }
 
         Spacer(modifier = Modifier.height(2.dp))
-        // Usage row - percentage right-aligned for consistency
+        // Usage row - percentage right-aligned, fixed width to prevent wrapping
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
                 text = "$used / $total",
                 fontFamily = JetBrainsMonoFamily,
                 fontSize = 9.sp,
+                maxLines = 1,
                 color = Primary,
+                modifier = Modifier.weight(1f, fill = false),
             )
             Text(
                 text = "($pct%)",
                 fontFamily = JetBrainsMonoFamily,
                 fontSize = 9.sp,
                 fontWeight = FontWeight.Bold,
+                maxLines = 1,
                 color = barColor,
             )
         }


### PR DESCRIPTION
## Summary
- BrutalistBottomNav: Explicitly use White background in light mode, DarkSurface in dark mode
- QuotaGauge: Add maxLines=1 + weight modifier to prevent percentage wrapping

## Changes

### BrutalistBottomNav
- Light mode: White bg + black border, selected item: black bg + white text
- Dark mode: DarkSurface (#131313) bg + white border, selected item: white bg + dark red text
- Fixes issue where bottom nav showed black background in light mode

### QuotaGauge  
- Added `maxLines = 1` to both usage text and percentage text
- Added `weight(1f, fill = false)` to usage text to give percentage fixed space
- Added `Alignment.CenterVertically` for consistent row height
- Prevents percentage from wrapping to second line for large token counts like 11896 / 4500026

## Test plan
- [x] Build passes
- [x] Lint passes  
- [ ] Manual testing: Light mode bottom nav should be white
- [ ] Manual testing: Dark mode bottom nav should be dark
- [ ] Manual testing: Quota gauge percentages should stay inline

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)