### PR TITLE
fix: quota gauge layout - percentage above progress bar

### DIFF
--- a/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
@@ -1076,14 +1076,27 @@ private fun QuotaGauge(label: String, used: Int, total: Int, modifier: Modifier 
             else -> Color.Gray
         }
 
-        Text(
-            text = label,
-            fontFamily = JetBrainsMonoFamily,
-            fontWeight = FontWeight.Bold,
-            fontSize = 8.sp,
-            letterSpacing = 1.sp,
-            color = Color.Gray,
-        )
+        // Label row with percentage on the right (above progress bar)
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                text = label,
+                fontFamily = JetBrainsMonoFamily,
+                fontWeight = FontWeight.Bold,
+                fontSize = 8.sp,
+                letterSpacing = 1.sp,
+                color = Color.Gray,
+            )
+            Text(
+                text = "$pct%",
+                fontFamily = JetBrainsMonoFamily,
+                fontWeight = FontWeight.Bold,
+                fontSize = 8.sp,
+                color = barColor,
+            )
+        }
         Spacer(modifier = Modifier.height(4.dp))
 
         // Progress bar background
@@ -1103,24 +1116,12 @@ private fun QuotaGauge(label: String, used: Int, total: Int, modifier: Modifier 
         }
 
         Spacer(modifier = Modifier.height(2.dp))
-        // Usage row - percentage right-aligned for consistency
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-        ) {
-            Text(
-                text = "$used / $total",
-                fontFamily = JetBrainsMonoFamily,
-                fontSize = 9.sp,
-                color = Primary,
-            )
-            Text(
-                text = "($pct%)",
-                fontFamily = JetBrainsMonoFamily,
-                fontSize = 9.sp,
-                fontWeight = FontWeight.Bold,
-                color = barColor,
-            )
-        }
+        // Usage row - just numbers, no percentage
+        Text(
+            text = "$used / $total",
+            fontFamily = JetBrainsMonoFamily,
+            fontSize = 9.sp,
+            color = Primary,
+        )
     }
 }


### PR DESCRIPTION
## Summary
- 将百分比移到进度条上方（标签行右边）
- 去掉百分比括号
- 使用行只显示数字 used / total

## Layout Change

Before:
```
Label
[Progress Bar]
used/total (pct%)
```

After:
```
Label          pct%
[Progress Bar]
used / total
```

Example: `5小时       21%`

## Benefits
- 窄屏上百分比不再与数字挤到一起
- 百分比与进度条颜色一致，视觉更清晰
- 格式简洁，无括号

## Test plan
- [x] Build passes
- [x] Lint passes
- [ ] Manual testing: 窄屏显示正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)