### PR TITLE
fix: remove duplicate visibility icon for Account credential type

### DIFF
--- a/app/src/main/java/com/lockit/ui/components/CredentialCard.kt
+++ b/app/src/main/java/com/lockit/ui/components/CredentialCard.kt
@@ -357,8 +357,8 @@ private fun CardHeader(
         }
         Row {
             // Reveal/hide button in header ONLY for types that don't have inline reveal in content
-            // CodingPlan and GitHub have RevealableValueBox in content, so skip header icon
-            if (!alwaysVisible && credential.type != CredentialType.CodingPlan && credential.type != CredentialType.GitHub) {
+            // CodingPlan, GitHub, Email, Account have RevealableValueBox or inline reveal in content, so skip header icon
+            if (!alwaysVisible && credential.type != CredentialType.CodingPlan && credential.type != CredentialType.GitHub && credential.type != CredentialType.Account) {
                 IconButtonBox(
                     icon = if (isRevealed) Icons.Default.VisibilityOff else Icons.Default.Visibility,
                     description = if (isRevealed) "Hide value" else "Reveal value",


### PR DESCRIPTION
## Summary
- Account type now only shows visibility icon in password reveal area
- Previously showed two visibility icons: one in header + one in password area
- Add Account to header exclusion list (alongside GitHub, CodingPlan)

## Problem
Account 类型的凭据卡片有两个 visibility 图标：
1. Header 区域有一个
2. Password 区域也有一个 reveal 按钮

用户提到 "Google card two eyes"，指的就是这个问题。

## Solution
在 header 的 visibility icon 条件中添加 `credential.type != CredentialType.Account`，使 Account 类型只在 password 区域显示 reveal 按钮。

## Changes
- `CredentialCard.kt`: 修改 header visibility icon 条件，排除 Account 类型

## Test plan
- [x] Build passes
- [x] Lint passes
- [ ] Manual testing: Account 卡片只有一个 visibility 图标

🤖 Generated with [Claude Code](https://claude.com/claude-code)