### PR TITLE
fix: add pagination to Logs screen for performance

### DIFF
--- a/app/src/main/java/com/lockit/ui/screens/logs/LogsScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/logs/LogsScreen.kt
@@ -2,6 +2,7 @@ package com.lockit.ui.screens.logs
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -16,8 +17,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AddCircle
-import androidx.compose.material.icons.filled.AutoDelete
-import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.AddCircleOutline
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
@@ -55,16 +55,25 @@ import com.lockit.ui.theme.IndustrialOrange
 import com.lockit.ui.theme.JetBrainsMonoFamily
 import com.lockit.ui.theme.Primary
 import com.lockit.ui.theme.TacticalRed
-import com.lockit.ui.theme.White
 import java.time.Instant
+
+private const val INITIAL_LOAD_COUNT = 100
+private const val LOAD_MORE_COUNT = 20
+private const val EXPORT_REMINDER_THRESHOLD = 200
 
 @Composable
 fun LogsScreen(
     modifier: Modifier = Modifier,
 ) {
     val app = LocalContext.current.applicationContext as LockitApp
-    // Show last 30 days
-    val logs by remember { mutableStateOf(app.auditLogger.getRecentEntries(days = 30)) }
+    val totalCount = remember { app.auditLogger.getTotalCount() }
+    var displayedCount by remember { mutableStateOf(INITIAL_LOAD_COUNT) }
+    var showExportReminder by remember { mutableStateOf(false) }
+
+    // Load only the displayed entries, not all
+    val logs = remember(displayedCount) {
+        app.auditLogger.getRecentEntriesByCount(displayedCount)
+    }
 
     Column(
         modifier = modifier
@@ -124,6 +133,68 @@ fun LogsScreen(
                 logs.forEach { entry ->
                     LogRow(entry)
                     Spacer(modifier = Modifier.height(4.dp))
+                }
+
+                // Load more button
+                if (displayedCount < totalCount) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .border(1.dp, IndustrialOrange)
+                            .clickable {
+                                val newCount = displayedCount + LOAD_MORE_COUNT
+                                displayedCount = minOf(newCount, totalCount)
+                                if (displayedCount >= EXPORT_REMINDER_THRESHOLD && !showExportReminder) {
+                                    showExportReminder = true
+                                }
+                            }
+                            .padding(12.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Icon(
+                                imageVector = Icons.Default.AddCircleOutline,
+                                contentDescription = null,
+                                tint = IndustrialOrange,
+                                modifier = Modifier.height(16.dp),
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                text = stringResource(R.string.logs_load_more),
+                                fontFamily = JetBrainsMonoFamily,
+                                fontWeight = FontWeight.Bold,
+                                fontSize = 12.sp,
+                                color = IndustrialOrange,
+                            )
+                        }
+                    }
+                    Text(
+                        text = stringResource(R.string.logs_remaining, totalCount - displayedCount),
+                        fontFamily = JetBrainsMonoFamily,
+                        fontSize = 10.sp,
+                        color = Color.Gray,
+                        modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
+                    )
+                }
+
+                // Export reminder
+                if (showExportReminder) {
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(IndustrialOrange.copy(0.1f))
+                            .border(1.dp, IndustrialOrange.copy(0.5f))
+                            .padding(12.dp),
+                    ) {
+                        Text(
+                            text = stringResource(R.string.logs_export_reminder),
+                            fontFamily = JetBrainsMonoFamily,
+                            fontSize = 10.sp,
+                            color = IndustrialOrange,
+                        )
+                    }
                 }
             }
 
@@ -224,4 +295,3 @@ private fun LogRow(entry: AuditEntry) {
         )
     }
 }
-

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -270,6 +270,9 @@
     <string name="logs_storage_local">存储: 仅本地设备</string>
     <string name="logs_retention">保留: 30天</string>
     <string name="logs_encryption">加密: AES-256-GCM</string>
+    <string name="logs_load_more">加载更多</string>
+    <string name="logs_remaining">剩余 %1$d 条</string>
+    <string name="logs_export_reminder">提示: 可在设置 > 导出日志中导出完整日志</string>
 
     <!-- Audit Action Names -->
     <string name="action_vault_initialized">密码库初始化</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -270,6 +270,9 @@
     <string name="logs_storage_local">STORAGE: LOCAL_DEVICE_ONLY</string>
     <string name="logs_retention">RETENTION: 30_DAYS</string>
     <string name="logs_encryption">ENCRYPTION: AES-256-GCM</string>
+    <string name="logs_load_more">LOAD_MORE</string>
+    <string name="logs_remaining">%1$d remaining</string>
+    <string name="logs_export_reminder">TIP: You can export full logs in Settings > Export Logs</string>
 
     <!-- Audit Action Names -->
     <string name="action_vault_initialized">VAULT_INITIALIZED</string>


### PR DESCRIPTION
## Summary
- Load initial 100 entries instead of all entries at once
- Add "Load More" button to load 20 more at a time  
- Show export reminder when viewing 200+ entries
- Prevents freeze when entering logs screen with many entries

## Changes
- LogsScreen.kt: Added pagination with INITIAL_LOAD_COUNT=100, LOAD_MORE_COUNT=20
- Added getRecentEntriesByCount() and getTotalCount() methods in AuditLogger
- strings.xml: Added logs_load_more, logs_remaining, logs_export_reminder

## Test plan
- [ ] Build passes
- [ ] Logs screen loads quickly without freeze
- [ ] Load More button works correctly
- [ ] Export reminder appears after 200+ loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)