### PR TITLE
fix: dynamic security info + logs pagination with background loading

### DIFF
--- a/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
@@ -429,12 +429,14 @@ fun ConfigScreen(
 
             Spacer(modifier = Modifier.height(24.dp))
 
-            // Security Section - Dynamic Argon2 params
+            // Security Section - Dynamic Argon2 params (calculated from actual values)
             val argon2Params = app.vaultManager.getArgon2ParamsInfo()
-            val (argon2Memory, argon2Iterations, argon2Parallelism) = argon2Params
-            val memoryStr = if (argon2Memory >= 65536) stringResource(R.string.config_64_mb) else stringResource(R.string.config_16_mb)
-            val iterStr = if (argon2Iterations >= 3) stringResource(R.string.config_3_iter) else stringResource(R.string.config_2_iter)
-            val parallelStr = if (argon2Parallelism >= 4) stringResource(R.string.config_4_parallel) else stringResource(R.string.config_1_parallel)
+            val (argon2MemoryKB, argon2Iterations, argon2Parallelism) = argon2Params
+            // Convert KB to MB for display (argon2MemoryKB is in KB)
+            val memoryMB = argon2MemoryKB / 1024
+            val memoryStr = "${memoryMB}MB"
+            val iterStr = argon2Iterations.toString()
+            val parallelStr = argon2Parallelism.toString()
 
             ConfigSection(
                 title = stringResource(R.string.config_security),

--- a/app/src/main/java/com/lockit/ui/screens/logs/LogsScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/logs/LogsScreen.kt
@@ -2,6 +2,7 @@ package com.lockit.ui.screens.logs
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -16,8 +17,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AddCircle
-import androidx.compose.material.icons.filled.AutoDelete
-import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.AddCircleOutline
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
@@ -33,6 +33,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -55,16 +56,41 @@ import com.lockit.ui.theme.IndustrialOrange
 import com.lockit.ui.theme.JetBrainsMonoFamily
 import com.lockit.ui.theme.Primary
 import com.lockit.ui.theme.TacticalRed
-import com.lockit.ui.theme.White
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.time.Instant
+
+private const val INITIAL_LOAD_COUNT = 100
+private const val LOAD_MORE_COUNT = 20
+private const val EXPORT_REMINDER_THRESHOLD = 200
 
 @Composable
 fun LogsScreen(
     modifier: Modifier = Modifier,
 ) {
     val app = LocalContext.current.applicationContext as LockitApp
-    // Show last 30 days
-    val logs by remember { mutableStateOf(app.auditLogger.getRecentEntries(days = 30)) }
+    var displayedCount by remember { mutableStateOf(INITIAL_LOAD_COUNT) }
+    var showExportReminder by remember { mutableStateOf(false) }
+
+    // Load logs on background thread using produceState
+    val logs by produceState<List<AuditEntry>>(
+        initialValue = emptyList(),
+        key1 = displayedCount,
+    ) {
+        // Run I/O operation on Dispatchers.IO to prevent ANR
+        value = withContext(Dispatchers.IO) {
+            app.auditLogger.getRecentEntriesByCount(displayedCount)
+        }
+    }
+
+    // Get total count on background thread
+    val totalCount by produceState<Int>(
+        initialValue = 0,
+    ) {
+        value = withContext(Dispatchers.IO) {
+            app.auditLogger.getTotalCount()
+        }
+    }
 
     Column(
         modifier = modifier
@@ -124,6 +150,68 @@ fun LogsScreen(
                 logs.forEach { entry ->
                     LogRow(entry)
                     Spacer(modifier = Modifier.height(4.dp))
+                }
+
+                // Load more button
+                if (displayedCount < totalCount) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .border(1.dp, IndustrialOrange)
+                            .clickable {
+                                val newCount = displayedCount + LOAD_MORE_COUNT
+                                displayedCount = minOf(newCount, totalCount)
+                                if (displayedCount >= EXPORT_REMINDER_THRESHOLD && !showExportReminder) {
+                                    showExportReminder = true
+                                }
+                            }
+                            .padding(12.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Icon(
+                                imageVector = Icons.Default.AddCircleOutline,
+                                contentDescription = null,
+                                tint = IndustrialOrange,
+                                modifier = Modifier.height(16.dp),
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                text = stringResource(R.string.logs_load_more),
+                                fontFamily = JetBrainsMonoFamily,
+                                fontWeight = FontWeight.Bold,
+                                fontSize = 12.sp,
+                                color = IndustrialOrange,
+                            )
+                        }
+                    }
+                    Text(
+                        text = stringResource(R.string.logs_remaining, totalCount - displayedCount),
+                        fontFamily = JetBrainsMonoFamily,
+                        fontSize = 10.sp,
+                        color = Color.Gray,
+                        modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
+                    )
+                }
+
+                // Export reminder
+                if (showExportReminder) {
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(IndustrialOrange.copy(0.1f))
+                            .border(1.dp, IndustrialOrange.copy(0.5f))
+                            .padding(12.dp),
+                    ) {
+                        Text(
+                            text = stringResource(R.string.logs_export_reminder),
+                            fontFamily = JetBrainsMonoFamily,
+                            fontSize = 10.sp,
+                            color = IndustrialOrange,
+                        )
+                    }
                 }
             }
 
@@ -224,4 +312,3 @@ private fun LogRow(entry: AuditEntry) {
         )
     }
 }
-

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -270,6 +270,9 @@
     <string name="logs_storage_local">存储: 仅本地设备</string>
     <string name="logs_retention">保留: 30天</string>
     <string name="logs_encryption">加密: AES-256-GCM</string>
+    <string name="logs_load_more">加载更多</string>
+    <string name="logs_remaining">剩余 %1$d 条</string>
+    <string name="logs_export_reminder">提示: 可在设置 > 导出日志中导出完整日志</string>
 
     <!-- Audit Action Names -->
     <string name="action_vault_initialized">密码库初始化</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -270,6 +270,9 @@
     <string name="logs_storage_local">STORAGE: LOCAL_DEVICE_ONLY</string>
     <string name="logs_retention">RETENTION: 30_DAYS</string>
     <string name="logs_encryption">ENCRYPTION: AES-256-GCM</string>
+    <string name="logs_load_more">LOAD_MORE</string>
+    <string name="logs_remaining">%1$d remaining</string>
+    <string name="logs_export_reminder">TIP: You can export full logs in Settings > Export Logs</string>
 
     <!-- Audit Action Names -->
     <string name="action_vault_initialized">VAULT_INITIALIZED</string>


### PR DESCRIPTION
## Summary

**1. Security Info Display Fix**
- Calculate Argon2 params dynamically instead of hardcoded thresholds
- Memory: KB to MB conversion (e.g. 65536KB → 64MB)
- Iterations: display actual value
- Parallelism: display actual value
- Shows correct values for both legacy (16MB/2/1) and OWASP (64MB/3/4) vaults

**2. Logs Screen Performance Fix (ANR Prevention)**
- Load initial 100 entries on Dispatchers.IO (background thread)
- "Load More" button for 20 more at a time
- Export reminder at 200+ entries
- Fix ANR risk from blocking I/O on main thread (SharedPreferences read)

## Changes
- `ConfigScreen.kt`: Dynamic Argon2 value calculation
- `LogsScreen.kt`: Pagination + produceState with Dispatchers.IO
- `strings.xml`: Added logs_load_more, logs_remaining, logs_export_reminder

## Test plan
- [ ] Build passes
- [ ] Security info shows correct dynamic values (not hardcoded)
- [ ] Logs screen loads quickly without freeze
- [ ] Load More button works correctly
- [ ] No ANR when loading logs

Closes #101 (security info not updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)