### PR TITLE
fix: replace hardcoded colors with MaterialTheme.colorScheme for dark theme

### DIFF
--- a/app/src/main/java/com/lockit/ui/components/BrutalistBottomNav.kt
+++ b/app/src/main/java/com/lockit/ui/components/BrutalistBottomNav.kt
@@ -54,10 +54,10 @@ fun BrutalistBottomNav(
     // Dark mode: DarkSurface background with white border
     val isDarkTheme = isSystemInDarkTheme()
     val backgroundColor = if (isDarkTheme) DarkSurface else White
-    val borderColor = if (isDarkTheme) Color.White else Primary
-    val selectedBgColor = if (isDarkTheme) Color.White else Primary
-    val selectedContentColor = if (isDarkTheme) Color(0xFF410000) else White  // Dark red on white / White on black
-    val unselectedContentColor = if (isDarkTheme) Color.White.copy(alpha = 0.7f) else Color(0xFF666666)
+    val borderColor = colorScheme.primary
+    val selectedBgColor = colorScheme.primary
+    val selectedContentColor = colorScheme.onPrimary
+    val unselectedContentColor = colorScheme.onSurfaceVariant
 
     Row(
         modifier = modifier

--- a/app/src/main/java/com/lockit/ui/components/BrutalistButton.kt
+++ b/app/src/main/java/com/lockit/ui/components/BrutalistButton.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
@@ -47,15 +48,20 @@ fun BrutalistButton(
     iconPosition: IconPosition = IconPosition.Start,
     customBorderColor: Color? = null,
 ) {
+    val colorScheme = MaterialTheme.colorScheme
     val colors = when (variant) {
-        ButtonVariant.Primary -> Triple(Primary, White, Color.Black)
-        ButtonVariant.Secondary -> Triple(Color.White, Primary, Color.Black)
+        ButtonVariant.Primary -> Triple(colorScheme.primary, colorScheme.onPrimary, colorScheme.primary)
+        ButtonVariant.Secondary -> Triple(colorScheme.background, colorScheme.primary, colorScheme.primary)
         ButtonVariant.Danger -> Triple(TacticalRed, White, TacticalRed)
         ButtonVariant.Warning -> Triple(IndustrialOrange, White, IndustrialOrange)
-        ButtonVariant.Revoke -> Triple(Color.White, TacticalRed, TacticalRed)
+        ButtonVariant.Revoke -> Triple(colorScheme.background, TacticalRed, TacticalRed)
     }
     val (bgColor, textColor, defaultBorderColor) = colors
     val borderColor = customBorderColor ?: defaultBorderColor
+
+    // Disabled state: use distinct colors for background vs text
+    val disabledBgColor = colorScheme.surfaceContainerHighest
+    val disabledContentColor = colorScheme.onSurfaceVariant
 
     val font = if (useMonoFont) JetBrainsMonoFamily else InterFontFamily
     val weight = if (useMonoFont) FontWeight.Medium else FontWeight.Bold
@@ -63,7 +69,7 @@ fun BrutalistButton(
     Box(
         modifier = modifier
             .border(1.dp, borderColor)
-            .background(if (enabled) bgColor else Color.Gray.copy(0.3f))
+            .background(if (enabled) bgColor else disabledBgColor)
             .clickable(enabled = enabled, onClick = onClick)
             .padding(horizontal = 12.dp, vertical = 6.dp),
         contentAlignment = Alignment.Center,
@@ -76,7 +82,7 @@ fun BrutalistButton(
                     Icon(
                         imageVector = icon,
                         contentDescription = null,
-                        tint = if (enabled) textColor else Color.Gray,
+                        tint = if (enabled) textColor else disabledContentColor,
                         modifier = Modifier.size(16.dp),
                     )
                     Spacer(modifier = Modifier.width(6.dp))
@@ -85,7 +91,7 @@ fun BrutalistButton(
                     text = text.uppercase(),
                     fontFamily = font,
                     fontWeight = weight,
-                    color = if (enabled) textColor else Color.Gray,
+                    color = if (enabled) textColor else disabledContentColor,
                     fontSize = if (useMonoFont) 10.sp else 12.sp,
                     letterSpacing = 1.sp,
                     textAlign = TextAlign.Center,
@@ -95,7 +101,7 @@ fun BrutalistButton(
                     Icon(
                         imageVector = icon,
                         contentDescription = null,
-                        tint = if (enabled) textColor else Color.Gray,
+                        tint = if (enabled) textColor else disabledContentColor,
                         modifier = Modifier.size(16.dp),
                     )
                 }
@@ -105,7 +111,7 @@ fun BrutalistButton(
                 text = text.uppercase(),
                 fontFamily = font,
                 fontWeight = weight,
-                color = if (enabled) textColor else Color.Gray,
+                color = if (enabled) textColor else disabledContentColor,
                 fontSize = if (useMonoFont) 10.sp else 12.sp,
                 letterSpacing = 1.sp,
                 textAlign = TextAlign.Center,

--- a/app/src/main/java/com/lockit/ui/components/BrutalistCard.kt
+++ b/app/src/main/java/com/lockit/ui/components/BrutalistCard.kt
@@ -23,7 +23,7 @@ fun BrutalistCard(
     Box(
         modifier = modifier
             .background(backgroundColor)
-            .border(1.dp, Color.Black)
+            .border(1.dp, MaterialTheme.colorScheme.primary)
             .padding(0.dp),
     ) {
         content()

--- a/app/src/main/java/com/lockit/ui/components/BrutalistPinVerifyDialog.kt
+++ b/app/src/main/java/com/lockit/ui/components/BrutalistPinVerifyDialog.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Fingerprint
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -103,7 +104,7 @@ fun BrutalistPinVerifyDialog(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(Color.Black.copy(0.5f))
+            .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f))
             .clickable(onClick = onDismiss),
         contentAlignment = Alignment.Center,
     ) {
@@ -112,7 +113,7 @@ fun BrutalistPinVerifyDialog(
             Column(
                 modifier = Modifier
                     .fillMaxWidth(0.85f)
-                    .background(White)
+                    .background(MaterialTheme.colorScheme.surfaceContainerHigh)
                     .border(2.dp, Primary),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
@@ -159,7 +160,7 @@ fun BrutalistPinVerifyDialog(
                         Box(
                             modifier = Modifier
                                 .size(6.dp)
-                                .background(White),
+                                .background(MaterialTheme.colorScheme.surfaceContainerHigh),
                         )
                     }
                 }
@@ -172,6 +173,7 @@ fun BrutalistPinVerifyDialog(
                     contentAlignment = Alignment.Center,
                 ) {
                     // Grid background
+                    val gridDotColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.05f)
                     Canvas(
                         modifier = Modifier
                             .fillMaxSize()
@@ -184,7 +186,7 @@ fun BrutalistPinVerifyDialog(
                             var y = 0f
                             while (y < size.height) {
                                 drawCircle(
-                                    color = Color.Black.copy(0.05f),
+                                    color = gridDotColor,
                                     radius = dotRadius,
                                     center = Offset(x, y),
                                 )
@@ -202,7 +204,7 @@ fun BrutalistPinVerifyDialog(
                             modifier = Modifier
                                 .size(96.dp)
                                 .border(1.dp, Primary)
-                                .background(White),
+                                .background(MaterialTheme.colorScheme.surfaceContainerHigh),
                             contentAlignment = Alignment.Center,
                         ) {
                             Icon(
@@ -384,7 +386,7 @@ private fun PinKey(
     Box(
         modifier = modifier
             .aspectRatio(4f / 3f)
-            .background(White)
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
             .drawBehind {
                 val sw = 1.dp.toPx()
                 if (hasRightBorder) {

--- a/app/src/main/java/com/lockit/ui/components/BrutalistShared.kt
+++ b/app/src/main/java/com/lockit/ui/components/BrutalistShared.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -55,7 +56,7 @@ fun ScreenHero(
             fontFamily = JetBrainsMonoFamily,
             fontWeight = FontWeight.ExtraBold,
             fontSize = 24.sp,  // Consistent size for all pages
-            color = Primary,
+            color = MaterialTheme.colorScheme.primary,
             letterSpacing = (-0.5).sp,
             maxLines = 1,
         )
@@ -64,7 +65,7 @@ fun ScreenHero(
             text = subtitle,
             fontFamily = JetBrainsMonoFamily,
             fontSize = 11.sp,
-            color = Color.Gray,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
             maxLines = 1,
         )
     }
@@ -77,15 +78,15 @@ fun InfoTag(
 ) {
     Box(
         modifier = modifier
-            .background(SurfaceHighest)
-            .border(1.dp, Primary)
+            .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+            .border(1.dp, MaterialTheme.colorScheme.primary)
             .padding(horizontal = 6.dp, vertical = 3.dp),
     ) {
         Text(
             text = text,
             fontFamily = JetBrainsMonoFamily,
             fontSize = 9.sp,
-            color = Primary,
+            color = MaterialTheme.colorScheme.primary,
             maxLines = 1,
             overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
         )
@@ -100,8 +101,8 @@ fun TerminalFooter(
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .background(SurfaceHighest)
-            .border(1.dp, Primary)
+            .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+            .border(1.dp, MaterialTheme.colorScheme.primary)
             .padding(12.dp),
     ) {
         Column {
@@ -221,7 +222,7 @@ fun BrutalistEmptyState(
                 text = message,
                 fontFamily = JetBrainsMonoFamily,
                 fontSize = 12.sp,
-                color = Color.Gray,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
     }

--- a/app/src/main/java/com/lockit/ui/components/BrutalistTextField.kt
+++ b/app/src/main/java/com/lockit/ui/components/BrutalistTextField.kt
@@ -74,7 +74,7 @@ fun BrutalistTextField(
                 .fillMaxWidth()
                 .border(
                     width = 1.dp,
-                    color = if (isFocused) IndustrialOrange else Color.Gray,
+                    color = if (isFocused) IndustrialOrange else MaterialTheme.colorScheme.outline,
                 )
                 .padding(12.dp),
             decorationBox = { innerTextField ->
@@ -83,7 +83,7 @@ fun BrutalistTextField(
                         text = placeholder,
                         fontFamily = JetBrainsMonoFamily,
                         fontSize = 14.sp,
-                        color = Color.Gray,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
                 innerTextField()

--- a/app/src/main/java/com/lockit/ui/components/BrutalistTopBar.kt
+++ b/app/src/main/java/com/lockit/ui/components/BrutalistTopBar.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -51,7 +52,7 @@ fun BrutalistTopBar(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .background(White),
+            .background(MaterialTheme.colorScheme.surface),
     ) {
         Row(
             modifier = Modifier

--- a/app/src/main/java/com/lockit/ui/components/CredentialCard.kt
+++ b/app/src/main/java/com/lockit/ui/components/CredentialCard.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.AnnotatedString
@@ -225,7 +226,7 @@ fun CredentialCard(
 
     Column(
         modifier = modifier
-            .border(1.dp, Color.Black)
+            .border(1.dp, MaterialTheme.colorScheme.primary)
             .clickable(onClick = onClick)
             .pointerInput(localRevealed) {
                 detectTapGestures(
@@ -350,7 +351,7 @@ private fun CardHeader(
                     if (credential.service.isNotBlank()) " // ${credential.service.uppercase()}" else "",
                 fontFamily = JetBrainsMonoFamily,
                 fontSize = 10.sp,
-                color = Color.Gray,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
@@ -761,7 +762,7 @@ private fun RevealableValueBox(
             text = if (isRevealed) value else maskPlaceholder,
             fontFamily = JetBrainsMonoFamily,
             fontSize = 13.sp,
-            color = if (isRevealed) Primary else Color.Gray,
+            color = if (isRevealed) Primary else MaterialTheme.colorScheme.onSurfaceVariant,
             maxLines = if (isRevealed) maxLinesRevealed else 1,
             overflow = TextOverflow.Ellipsis,
         )

--- a/app/src/main/java/com/lockit/ui/components/CredentialFormComponents.kt
+++ b/app/src/main/java/com/lockit/ui/components/CredentialFormComponents.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.outlined.ArrowDropUp
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -63,7 +64,7 @@ fun DropdownWithCustomInput(
             text = label,
             fontFamily = JetBrainsMonoFamily,
             fontSize = 10.sp,
-            color = Color.Gray,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
         Spacer(modifier = Modifier.height(4.dp))
 
@@ -72,7 +73,7 @@ fun DropdownWithCustomInput(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .border(1.dp, if (error != null) TacticalRed else Color.Gray)
+                    .border(1.dp, if (error != null) TacticalRed else MaterialTheme.colorScheme.outline)
                     .clickable { expanded = true }
                     .padding(12.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
@@ -82,14 +83,14 @@ fun DropdownWithCustomInput(
                     text = if (selectedValue.isBlank()) "SELECT..." else selectedValue,
                     fontFamily = JetBrainsMonoFamily,
                     fontSize = 14.sp,
-                    color = if (selectedValue.isBlank()) Color.Gray else Color.Black,
+                    color = if (selectedValue.isBlank()) MaterialTheme.colorScheme.onSurfaceVariant else MaterialTheme.colorScheme.onSurface,
                     modifier = Modifier.weight(1f),
                     maxLines = 1,
                 )
                 Icon(
                     imageVector = if (expanded) Icons.Outlined.ArrowDropUp else Icons.Default.ArrowDropDown,
                     contentDescription = "Toggle dropdown",
-                    tint = Color.Black,
+                    tint = MaterialTheme.colorScheme.primary,
                 )
             }
 
@@ -97,8 +98,8 @@ fun DropdownWithCustomInput(
                 expanded = expanded,
                 onDismissRequest = { expanded = false },
                 modifier = Modifier
-                    .background(White)
-                    .border(1.dp, Color.Black),
+                    .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                    .border(1.dp, MaterialTheme.colorScheme.primary),
             ) {
                 presets.forEach { preset ->
                     DropdownMenuItem(
@@ -168,7 +169,7 @@ fun ChipGroup(
             text = label,
             fontFamily = JetBrainsMonoFamily,
             fontSize = 10.sp,
-            color = Color.Gray,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
         Spacer(modifier = androidx.compose.ui.Modifier.height(8.dp))
 
@@ -225,7 +226,7 @@ private fun Chip(
 ) {
     Box(
         modifier = Modifier
-            .border(1.dp, if (selected) Primary else Color.Gray)
+            .border(1.dp, if (selected) Primary else MaterialTheme.colorScheme.outline)
             .background(if (selected) Primary else Color.Transparent)
             .clickable(onClick = onClick)
             .padding(horizontal = 10.dp, vertical = 4.dp),
@@ -235,7 +236,7 @@ private fun Chip(
             text = text,
             fontFamily = JetBrainsMonoFamily,
             fontSize = 10.sp,
-            color = if (selected) White else Color.Gray,
+            color = if (selected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant,
             fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal,
         )
     }
@@ -258,7 +259,7 @@ fun CredentialTypeDropdown(
             text = "TYPE",
             fontFamily = JetBrainsMonoFamily,
             fontSize = 10.sp,
-            color = Color.Gray,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
         Spacer(modifier = Modifier.height(4.dp))
 
@@ -266,7 +267,7 @@ fun CredentialTypeDropdown(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .border(1.dp, Color.Gray)
+                    .border(1.dp, MaterialTheme.colorScheme.outline)
                     .clickable { onExpandedChange(!expanded) }
                     .padding(12.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
@@ -276,13 +277,13 @@ fun CredentialTypeDropdown(
                     text = selectedType.displayName,
                     fontFamily = JetBrainsMonoFamily,
                     fontSize = 14.sp,
-                    color = Color.Black,
+                    color = MaterialTheme.colorScheme.onSurface,
                     modifier = Modifier.weight(1f),
                 )
                 Icon(
                     imageVector = if (expanded) Icons.Outlined.ArrowDropUp else Icons.Default.ArrowDropDown,
                     contentDescription = "Toggle dropdown",
-                    tint = Color.Black,
+                    tint = MaterialTheme.colorScheme.primary,
                 )
             }
 
@@ -290,8 +291,8 @@ fun CredentialTypeDropdown(
                 expanded = expanded,
                 onDismissRequest = { onExpandedChange(false) },
                 modifier = Modifier
-                    .background(White)
-                    .border(1.dp, Color.Black),
+                    .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                    .border(1.dp, MaterialTheme.colorScheme.primary),
             ) {
                 CredentialType.entries.forEach { type ->
                     DropdownMenuItem(
@@ -312,7 +313,7 @@ fun CredentialTypeDropdown(
                                 text = "─── CUSTOM ───",
                                 fontFamily = JetBrainsMonoFamily,
                                 fontSize = 10.sp,
-                                color = Color.Gray,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
                         },
                         onClick = {},
@@ -364,8 +365,8 @@ fun CredentialTypeDropdown(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .background(White)
-                    .border(2.dp, Color.Black)
+                    .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                    .border(2.dp, MaterialTheme.colorScheme.primary)
                     .padding(24.dp),
             ) {
                 Text(

--- a/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
@@ -344,7 +344,7 @@ fun ConfigScreen(
                             Row(
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .border(1.dp, Color.Gray)
+                                    .border(1.dp, MaterialTheme.colorScheme.outline)
                                     .padding(8.dp),
                                 verticalAlignment = Alignment.CenterVertically,
                             ) {
@@ -352,7 +352,7 @@ fun ConfigScreen(
                                     text = stringResource(R.string.config_signed_in),
                                     fontFamily = JetBrainsMonoFamily,
                                     fontSize = 9.sp,
-                                    color = Color.Gray,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
                                 Spacer(modifier = Modifier.width(4.dp))
                                 Text(
@@ -368,7 +368,7 @@ fun ConfigScreen(
                                         text = "${stringResource(R.string.config_last_sync)} ${lastBackupTime?.take(19) ?: "N/A"}",
                                         fontFamily = JetBrainsMonoFamily,
                                         fontSize = 8.sp,
-                                        color = Color.Gray,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                                     )
                                 }
                             }
@@ -640,7 +640,7 @@ fun ConfigScreen(
                                 text = stringResource(R.string.config_current_version),
                                 fontFamily = JetBrainsMonoFamily,
                                 fontSize = 10.sp,
-                                color = Color.Gray,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
                             Text(
                                 text = "$currentVersion ($currentVersionCode)",
@@ -661,7 +661,7 @@ fun ConfigScreen(
                                 text = stringResource(R.string.config_token_source),
                                 fontFamily = JetBrainsMonoFamily,
                                 fontSize = 10.sp,
-                                color = Color.Gray,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
                             Row(verticalAlignment = Alignment.CenterVertically) {
                                 Text(
@@ -745,9 +745,9 @@ fun ConfigScreen(
             TerminalFooter(
                 lines = listOf(
                     stringResource(R.string.footer_system_info) to IndustrialOrange,
-                    versionString to Color.Gray,
-                    stringResource(R.string.footer_compatible) to Color.Gray,
-                    stringResource(R.string.footer_design) to Color.Gray,
+                    versionString to MaterialTheme.colorScheme.onSurfaceVariant,
+                    stringResource(R.string.footer_compatible) to MaterialTheme.colorScheme.onSurfaceVariant,
+                    stringResource(R.string.footer_design) to MaterialTheme.colorScheme.onSurfaceVariant,
                 ),
             )
         }
@@ -1086,7 +1086,7 @@ private fun ConfigSection(
                     text = label,
                     fontFamily = JetBrainsMonoFamily,
                     fontSize = 10.sp,
-                    color = Color.Gray,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 Text(
                     text = value,
@@ -1145,7 +1145,7 @@ private fun UpdateDialog(
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(150.dp)
-                        .border(1.dp, Color.Gray)
+                        .border(1.dp, MaterialTheme.colorScheme.outline)
                         .verticalScroll(rememberScrollState())
                         .padding(8.dp),
                 ) {
@@ -1153,7 +1153,7 @@ private fun UpdateDialog(
                         text = release.changelog,
                         fontFamily = JetBrainsMonoFamily,
                         fontSize = 9.sp,
-                        color = Color.Gray,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
             }
@@ -1165,7 +1165,7 @@ private fun UpdateDialog(
                     text = "${context.getString(R.string.update_size)} ${release.downloadSize / 1024 / 1024} MB",
                     fontFamily = JetBrainsMonoFamily,
                     fontSize = 9.sp,
-                    color = Color.Gray,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
 
@@ -1228,7 +1228,7 @@ private fun GitHubTokenConfigDialog(
                 text = context.getString(R.string.github_token_desc),
                 fontFamily = JetBrainsMonoFamily,
                 fontSize = 10.sp,
-                color = Color.Gray,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
                 lineHeight = 14.sp,
             )
             Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/lockit/ui/screens/edit_credential/EditCredentialScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/edit_credential/EditCredentialScreen.kt
@@ -77,7 +77,7 @@ fun EditCredentialScreen(
                 text = "LOADING...",
                 fontFamily = JetBrainsMonoFamily,
                 fontSize = 14.sp,
-                color = Color.Gray,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
         return

--- a/app/src/main/java/com/lockit/ui/screens/logs/LogsScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/logs/LogsScreen.kt
@@ -128,7 +128,7 @@ fun LogsScreen(
                     text = stringResource(R.string.logs_entries, logs.size),
                     fontFamily = JetBrainsMonoFamily,
                     fontSize = 10.sp,
-                    color = Color.Gray,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
 
@@ -143,7 +143,7 @@ fun LogsScreen(
                         text = stringResource(R.string.logs_no_events),
                         fontFamily = JetBrainsMonoFamily,
                         fontSize = 14.sp,
-                        color = Color.Gray,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
             } else {
@@ -190,7 +190,7 @@ fun LogsScreen(
                         text = stringResource(R.string.logs_remaining, totalCount - displayedCount),
                         fontFamily = JetBrainsMonoFamily,
                         fontSize = 10.sp,
-                        color = Color.Gray,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
                     )
                 }
@@ -220,9 +220,9 @@ fun LogsScreen(
             TerminalFooter(
                 lines = listOf(
                     "> AUDIT_LOG_STATUS:" to IndustrialOrange,
-                    stringResource(R.string.logs_storage_local) to Color.Gray,
-                    stringResource(R.string.logs_retention) to Color.Gray,
-                    stringResource(R.string.logs_encryption) to Color.Gray,
+                    stringResource(R.string.logs_storage_local) to MaterialTheme.colorScheme.onSurfaceVariant,
+                    stringResource(R.string.logs_retention) to MaterialTheme.colorScheme.onSurfaceVariant,
+                    stringResource(R.string.logs_encryption) to MaterialTheme.colorScheme.onSurfaceVariant,
                 ),
             )
         }
@@ -268,7 +268,7 @@ private fun LogRow(entry: AuditEntry) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .border(1.dp, Color.Black.copy(0.15f))
+            .border(1.dp, MaterialTheme.colorScheme.primary.copy(0.15f))
             .background(
                 when (entry.severity) {
                     AuditSeverity.Info -> Color.Transparent
@@ -300,7 +300,7 @@ private fun LogRow(entry: AuditEntry) {
                     text = entry.detail,
                     fontFamily = JetBrainsMonoFamily,
                     fontSize = 10.sp,
-                    color = Color.Gray,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
         }
@@ -308,7 +308,7 @@ private fun LogRow(entry: AuditEntry) {
             text = formatTime(Instant.ofEpochMilli(entry.timestamp)),
             fontFamily = JetBrainsMonoFamily,
             fontSize = 9.sp,
-            color = Color.Gray.copy(0.6f),
+            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(0.6f),
         )
     }
 }

--- a/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
@@ -446,9 +446,9 @@ fun ReposScreen(
                 TerminalFooter(
                     lines = listOf(
                         stringResource(R.string.repos_status) to IndustrialOrange,
-                        stringResource(R.string.repos_local_vault_active) to Color.Gray,
-                        stringResource(R.string.repos_remote_sync_not_configured) to Color.Gray,
-                        stringResource(R.string.repos_last_sync_never) to Color.Gray,
+                        stringResource(R.string.repos_local_vault_active) to MaterialTheme.colorScheme.onSurfaceVariant,
+                        stringResource(R.string.repos_remote_sync_not_configured) to MaterialTheme.colorScheme.onSurfaceVariant,
+                        stringResource(R.string.repos_last_sync_never) to MaterialTheme.colorScheme.onSurfaceVariant,
                     ),
                 )
             }
@@ -591,7 +591,7 @@ fun ReposScreen(
                         text = stringResource(R.string.repos_entries, list.size),
                         fontFamily = JetBrainsMonoFamily,
                         fontSize = 10.sp,
-                        color = Color.Gray,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
                 Spacer(modifier = Modifier.height(8.dp))
@@ -643,7 +643,7 @@ fun ReposScreen(
                                     text = if (searchQuery.isNotBlank()) stringResource(R.string.repos_no_matching_credentials) else stringResource(R.string.explorer_no_credentials),
                                     fontFamily = JetBrainsMonoFamily,
                                     fontSize = 14.sp,
-                                    color = Color.Gray,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
                             }
                         }
@@ -654,9 +654,9 @@ fun ReposScreen(
                         TerminalFooter(
                             lines = listOf(
                                 stringResource(R.string.repos_status) to IndustrialOrange,
-                                stringResource(R.string.repos_local_vault_active) to Color.Gray,
-                                stringResource(R.string.repos_remote_sync_not_configured) to Color.Gray,
-                                stringResource(R.string.repos_last_sync_never) to Color.Gray,
+                                stringResource(R.string.repos_local_vault_active) to MaterialTheme.colorScheme.onSurfaceVariant,
+                                stringResource(R.string.repos_remote_sync_not_configured) to MaterialTheme.colorScheme.onSurfaceVariant,
+                                stringResource(R.string.repos_last_sync_never) to MaterialTheme.colorScheme.onSurfaceVariant,
                             ),
                         )
                         Spacer(modifier = Modifier.height(16.dp))
@@ -701,7 +701,7 @@ private fun StatCard(label: String, value: String, modifier: Modifier = Modifier
                 text = label,
                 fontFamily = JetBrainsMonoFamily,
                 fontSize = 10.sp,
-                color = Color.Gray,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
     }
@@ -727,7 +727,7 @@ private fun ServiceRow(
             Icon(
                 imageVector = if (isLocal) Icons.Default.Lock else Icons.Default.CloudUpload,
                 contentDescription = null,
-                tint = if (isLocal) IndustrialOrange else Color.Gray,
+                tint = if (isLocal) IndustrialOrange else MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.height(16.dp),
             )
             Spacer(modifier = Modifier.width(8.dp))
@@ -744,13 +744,13 @@ private fun ServiceRow(
                 text = stringResource(R.string.repos_keys, count),
                 fontFamily = JetBrainsMonoFamily,
                 fontSize = 10.sp,
-                color = Color.Gray,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Spacer(modifier = Modifier.width(8.dp))
             Box(
                 modifier = Modifier
-                    .background(if (isLocal) SurfaceHighest else Color.Gray.copy(0.2f))
-                    .border(1.dp, if (isLocal) Primary else Color.Gray)
+                    .background(if (isLocal) MaterialTheme.colorScheme.surfaceContainerHighest else MaterialTheme.colorScheme.surfaceContainer.copy(alpha = 0.2f))
+                    .border(1.dp, if (isLocal) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline)
                     .padding(horizontal = 6.dp, vertical = 2.dp),
             ) {
                 Text(
@@ -758,7 +758,7 @@ private fun ServiceRow(
                     fontFamily = JetBrainsMonoFamily,
                     fontSize = 8.sp,
                     fontWeight = FontWeight.Bold,
-                    color = if (isLocal) Primary else Color.Gray,
+                    color = if (isLocal) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
         }
@@ -778,7 +778,7 @@ internal fun CompactCredentialRow(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .border(1.dp, Color.Black)
+            .border(1.dp, MaterialTheme.colorScheme.primary)
             .clickable(onClick = onClick)
             .padding(12.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
@@ -829,7 +829,7 @@ internal fun CompactCredentialRow(
                     text = subtitle,
                     fontFamily = JetBrainsMonoFamily,
                     fontSize = 11.sp,
-                    color = Color.Gray,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
@@ -839,7 +839,7 @@ internal fun CompactCredentialRow(
             text = ">",
             fontFamily = JetBrainsMonoFamily,
             fontSize = 14.sp,
-            color = Color.Gray,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
 }
@@ -861,7 +861,7 @@ internal fun CredentialCardModal(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(Color.Black.copy(0.5f))
+            .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f))
             .clickable(onClick = onDismiss),
         contentAlignment = Alignment.Center,
     ) {
@@ -887,7 +887,7 @@ internal fun CredentialCardModal(
                 text = stringResource(R.string.repos_modal_close_hint),
                 fontFamily = JetBrainsMonoFamily,
                 fontSize = 9.sp,
-                color = Color.Gray,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.align(Alignment.CenterHorizontally),
             )
             Spacer(modifier = Modifier.height(16.dp))
@@ -932,7 +932,7 @@ private fun CodingPlanBoard(
                     text = stringResource(R.string.repos_fetching),
                     fontFamily = JetBrainsMonoFamily,
                     fontSize = 9.sp,
-                    color = Color.Gray,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             } else {
                 Box(
@@ -965,7 +965,7 @@ private fun CodingPlanBoard(
                         text = stringResource(R.string.repos_quota_remaining, quota.remainingDays),
                         fontFamily = JetBrainsMonoFamily,
                         fontSize = 10.sp,
-                        color = Color.Gray,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier.weight(1f, fill = false),
@@ -974,7 +974,7 @@ private fun CodingPlanBoard(
                         text = stringResource(R.string.repos_quota_cost, quota.chargeAmount),
                         fontFamily = JetBrainsMonoFamily,
                         fontSize = 10.sp,
-                        color = Color.Gray,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                         maxLines = 1,
                     )
                 }
@@ -1057,7 +1057,7 @@ private fun CodingPlanBoard(
                         text = stringResource(R.string.repos_quota_retry_hint),
                         fontFamily = JetBrainsMonoFamily,
                         fontSize = 9.sp,
-                        color = Color.Gray,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
             }
@@ -1073,7 +1073,7 @@ private fun QuotaGauge(label: String, used: Int, total: Int, modifier: Modifier 
         val barColor = when {
             pct >= 90 -> TacticalRed
             pct >= 70 -> IndustrialOrange
-            else -> Color.Gray
+            else -> MaterialTheme.colorScheme.onSurfaceVariant
         }
 
         // Label row with percentage on the right (above progress bar)
@@ -1087,7 +1087,7 @@ private fun QuotaGauge(label: String, used: Int, total: Int, modifier: Modifier 
                 fontWeight = FontWeight.Bold,
                 fontSize = 8.sp,
                 letterSpacing = 1.sp,
-                color = Color.Gray,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Text(
                 text = "$pct%",

--- a/app/src/main/java/com/lockit/ui/screens/secret_details/SecretDetailsScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/secret_details/SecretDetailsScreen.kt
@@ -129,7 +129,7 @@ fun SecretDetailsScreen(
                 text = "LOADING...",
                 fontFamily = JetBrainsMonoFamily,
                 fontSize = 14.sp,
-                color = Color.Gray,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
         return
@@ -160,7 +160,7 @@ fun SecretDetailsScreen(
         return
     }
 
-    Column(modifier = modifier.fillMaxSize().background(White)) {
+    Column(modifier = modifier.fillMaxSize().background(MaterialTheme.colorScheme.surface)) {
         BrutalistTopBar(showBackButton = true, onBackClick = onBack)
 
         LazyColumn(modifier = Modifier.fillMaxSize().padding(16.dp)) {
@@ -193,7 +193,7 @@ fun SecretDetailsScreen(
                     text = "ID: ${cred.refId()} // Created: ${cred.formatCreatedAt()}",
                     fontFamily = JetBrainsMonoFamily,
                     fontSize = 10.sp,
-                    color = Color.Gray,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 Spacer(modifier = Modifier.height(24.dp))
             }
@@ -493,7 +493,7 @@ private fun SecretValueSection(
                                 text = if (passwordRevealed) displayPassword else "\u2022".repeat(20),
                                 fontFamily = JetBrainsMonoFamily,
                                 fontSize = 13.sp,
-                                color = if (passwordRevealed) Primary else Color.Gray,
+                                color = if (passwordRevealed) Primary else MaterialTheme.colorScheme.onSurfaceVariant,
                                 maxLines = if (passwordRevealed) 5 else 1,
                                 overflow = TextOverflow.Ellipsis,
                             )
@@ -553,7 +553,7 @@ private fun SecretValueSection(
                             text = displayValue,
                             fontFamily = JetBrainsMonoFamily,
                             fontSize = 14.sp,
-                            color = if (isRevealed) Primary else Color.Gray,
+                            color = if (isRevealed) Primary else MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }
                 }
@@ -612,7 +612,7 @@ private fun MetaCard(label: String, value: String, modifier: Modifier = Modifier
                 text = label,
                 fontFamily = JetBrainsMonoFamily,
                 fontSize = 10.sp,
-                color = Color.Gray,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Spacer(modifier = Modifier.height(4.dp))
             Text(
@@ -669,7 +669,7 @@ private fun AuditLogSection(app: LockitApp, credential: Credential) {
                     text = "NO_AUDIT_EVENTS",
                     fontFamily = JetBrainsMonoFamily,
                     fontSize = 10.sp,
-                    color = Color.Gray,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(horizontal = 12.dp, vertical = 12.dp),
                 )
             } else {
@@ -724,7 +724,7 @@ private fun AuditLogSection(app: LockitApp, credential: Credential) {
                                     text = entry.detail,
                                     fontFamily = JetBrainsMonoFamily,
                                     fontSize = 9.sp,
-                                    color = Color.Gray,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
                             }
                         }
@@ -732,11 +732,11 @@ private fun AuditLogSection(app: LockitApp, credential: Credential) {
                             text = formatTime(Instant.ofEpochMilli(entry.timestamp)),
                             fontFamily = JetBrainsMonoFamily,
                             fontSize = 9.sp,
-                            color = Color.Gray.copy(0.6f),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
                         )
                     }
                     if (index < logs.size - 1) {
-                        HorizontalDivider(color = Color.Black.copy(0.15f), thickness = 1.dp)
+                        HorizontalDivider(color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.15f), thickness = 1.dp)
                     }
                 }
             }

--- a/app/src/main/java/com/lockit/ui/screens/vault_explorer/VaultExplorerScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/vault_explorer/VaultExplorerScreen.kt
@@ -265,7 +265,7 @@ fun VaultExplorerScreen(
                             text = stringResource(R.string.explorer_quick_start_desc),
                             fontFamily = JetBrainsMonoFamily,
                             fontSize = 10.sp,
-                            color = Color.Gray,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                             lineHeight = 14.sp,
                         )
                     }
@@ -313,7 +313,7 @@ fun VaultExplorerScreen(
                         text = "${credentials.size} " + stringResource(R.string.explorer_entries),
                         fontFamily = JetBrainsMonoFamily,
                         fontSize = 10.sp,
-                        color = Color.Gray,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
                 Spacer(modifier = Modifier.height(8.dp))
@@ -366,7 +366,7 @@ fun VaultExplorerScreen(
                             text = stringResource(R.string.explorer_no_credentials),
                             fontFamily = JetBrainsMonoFamily,
                             fontSize = 14.sp,
-                            color = Color.Gray,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }
                 }
@@ -376,10 +376,10 @@ fun VaultExplorerScreen(
                 Spacer(modifier = Modifier.height(16.dp))
                 TerminalFooter(
                     lines = listOf(
-                        stringResource(R.string.explorer_daemon) to Color.Gray,
-                        stringResource(R.string.explorer_total_credentials) + " ${credentials.size}" to Color.Gray,
-                        if (services.isNotEmpty()) stringResource(R.string.explorer_services) + " ${services.take(3).joinToString(", ")}${if (services.size > 3) "..." else ""}" to Color.Gray
-                        else stringResource(R.string.explorer_no_services) to Color.Gray,
+                        stringResource(R.string.explorer_daemon) to MaterialTheme.colorScheme.onSurfaceVariant,
+                        stringResource(R.string.explorer_total_credentials) + " ${credentials.size}" to MaterialTheme.colorScheme.onSurfaceVariant,
+                        if (services.isNotEmpty()) stringResource(R.string.explorer_services) + " ${services.take(3).joinToString(", ")}${if (services.size > 3) "..." else ""}" to MaterialTheme.colorScheme.onSurfaceVariant
+                        else stringResource(R.string.explorer_no_services) to MaterialTheme.colorScheme.onSurfaceVariant,
                     ),
                 )
                 Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/lockit/ui/screens/vault_unlock/VaultUnlockScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/vault_unlock/VaultUnlockScreen.kt
@@ -315,7 +315,7 @@ fun VaultUnlockScreen(
                         text = stringResource(R.string.vault_subtitle),
                         fontFamily = JetBrainsMonoFamily,
                         fontSize = 8.sp,
-                        color = Color.Black.copy(0.6f),
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
                         letterSpacing = 2.sp,
                     )
                 }
@@ -354,7 +354,7 @@ fun VaultUnlockScreen(
                                 fontSize = 8.sp,
                                 color = if (viewModel.isProcessing) IndustrialOrange
                                     else if (viewModel.isConfirmStep) IndustrialOrange
-                                    else Color.Black.copy(0.5f),
+                                    else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
                                 letterSpacing = 1.sp,
                             )
                             Spacer(modifier = Modifier.height(8.dp))
@@ -513,7 +513,7 @@ fun VaultUnlockScreen(
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(Color.Black.copy(0.7f))
+                    .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f))
                     .clickable(enabled = false) {},
                 contentAlignment = Alignment.Center,
             ) {
@@ -544,7 +544,7 @@ fun VaultUnlockScreen(
                         text = stringResource(R.string.vault_link_biometric_desc),
                         fontFamily = JetBrainsMonoFamily,
                         fontSize = 10.sp,
-                        color = Color.Gray,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                     Spacer(modifier = Modifier.height(16.dp))
                     Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -615,14 +615,14 @@ fun VaultUnlockScreen(
                     text = stringResource(R.string.vault_os_ver),
                     fontFamily = JetBrainsMonoFamily,
                     fontSize = 9.sp,
-                    color = Color.White.copy(0.6f),
+                    color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.6f),
                 )
             }
             Text(
                 text = stringResource(R.string.vault_node_id),
                 fontFamily = JetBrainsMonoFamily,
                 fontSize = 9.sp,
-                color = Color.White.copy(0.4f),
+                color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.4f),
             )
         }
     }
@@ -732,6 +732,7 @@ private fun KeypadKey(
 
 @Composable
 private fun BrutalistGridBackground() {
+    val dotColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.03f)
     Canvas(modifier = Modifier.fillMaxSize()) {
         val dotRadius = 0.5.dp.toPx()
         val gridSize = 20.dp.toPx()
@@ -742,7 +743,7 @@ private fun BrutalistGridBackground() {
             var y = gridSize / 2
             while (y < h) {
                 drawCircle(
-                    color = Color.Black.copy(alpha = 0.03f),
+                    color = dotColor,
                     radius = dotRadius,
                     center = Offset(x, y),
                 )


### PR DESCRIPTION
## Summary
Replace hardcoded Color.Gray/Color.Black/Color.White with MaterialTheme.colorScheme values for proper dark theme support.

## Changes
- BrutalistButton: use colorScheme for primary/onPrimary/background
- BrutalistCard: use colorScheme.primary for border
- BrutalistShared: use colorScheme for surfaceContainerHighest, primary, onSurfaceVariant
- BrutalistTextField: use colorScheme.outline and onSurfaceVariant
- CredentialCard: use colorScheme.primary and onSurfaceVariant
- CredentialFormComponents: use colorScheme for all colors
- LogsScreen: use colorScheme.onSurfaceVariant and primary

## Test plan
- [ ] Build passes
- [ ] Dark theme: borders and text visible (not hardcoded white/black)
- [ ] Light theme: still works correctly

Partially addresses #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)