### PR TITLE
fix: update Qwen Coding Plan default Base URL

### DIFF
--- a/app/src/main/java/com/lockit/ui/screens/add_credential/AddCredentialScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/add_credential/AddCredentialScreen.kt
@@ -119,7 +119,7 @@ private val PROVIDER_BASE_URLS = mapOf(
     "moonshot" to listOf("https://api.moonshot.cn/v1"),
     "minimax" to listOf("https://api.minimax.chat/v1"),
     "glm" to listOf("https://open.bigmodel.cn/api/paas/v4"),
-    "qwen" to listOf("https://dashscope.aliyuncs.com/api/v1"),
+    "qwen" to listOf("https://coding.dashscope.aliyuncs.com/v1"),
     "qwen_bailian" to listOf("https://bailian.console.aliyun.com"),
 )
 


### PR DESCRIPTION
## Summary
- Update Qwen Coding Plan default Base URL from `https://dashscope.aliyuncs.com/api/v1` to `https://coding.dashscope.aliyuncs.com/v1`

## Changes
- `AddCredentialScreen.kt`: Update SERVICE_PRESETS "qwen" entry

## Test plan
- [ ] Create new Qwen credential
- [ ] Verify default Base URL is correct

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)