### PR TITLE
enhance: optimize biometric UX on lock screen

### DIFF
--- a/app/src/main/java/com/lockit/data/biometric/BiometricPinStorage.kt
+++ b/app/src/main/java/com/lockit/data/biometric/BiometricPinStorage.kt
@@ -28,10 +28,19 @@ class BiometricPinStorage(private val sharedPreferences: SharedPreferences) {
         private const val ENCRYPTED_PIN_KEY = "encrypted_pin"
         private const val IV_KEY = "pin_iv"
         private const val TRANSFORMATION = "AES/GCM/NoPadding"
+        private const val BIOMETRIC_PROMPTED_KEY = "biometric_prompted"
     }
 
     fun isBiometricLinked(): Boolean {
         return sharedPreferences.getString(ENCRYPTED_PIN_KEY, null) != null
+    }
+
+    fun hasBeenPromptedForBiometric(): Boolean {
+        return sharedPreferences.getBoolean(BIOMETRIC_PROMPTED_KEY, false)
+    }
+
+    fun setBiometricPrompted(prompted: Boolean) {
+        sharedPreferences.edit().putBoolean(BIOMETRIC_PROMPTED_KEY, prompted).apply()
     }
 
     fun canAuthenticate(activity: FragmentActivity): Boolean {

--- a/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
@@ -1047,13 +1047,17 @@ private fun LinkBiometricDialog(
                             return@BrutalistButton
                         }
 
+                        // Capture PIN value BEFORE async verification to prevent race condition
+                        // If user modifies input during async operation, we verify/store the original value
+                        val pinToVerify = pin
+
                         // Set linking state immediately to prevent race condition (multiple clicks)
                         isLinking = true
 
                         // First verify PIN is correct
                         scope.launch {
                             val verifyResult = withContext(Dispatchers.IO) {
-                                app.vaultManager.unlockVault(pin)
+                                app.vaultManager.unlockVault(pinToVerify)
                             }
                             if (verifyResult.isFailure) {
                                 isLinking = false
@@ -1077,9 +1081,10 @@ private fun LinkBiometricDialog(
                                 return@launch
                             }
 
+                            // Use the captured PIN value, NOT the mutable pin state
                             biometricStorage.storePin(
                                 activity = activity,
-                                pin = pin,
+                                pin = pinToVerify,
                                 title = context.getString(R.string.biometric_link_pin_title),
                                 subtitle = context.getString(R.string.biometric_link_pin_subtitle),
                                 onSuccess = {

--- a/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
@@ -1047,12 +1047,16 @@ private fun LinkBiometricDialog(
                             return@BrutalistButton
                         }
 
+                        // Set linking state immediately to prevent race condition (multiple clicks)
+                        isLinking = true
+
                         // First verify PIN is correct
                         scope.launch {
                             val verifyResult = withContext(Dispatchers.IO) {
                                 app.vaultManager.unlockVault(pin)
                             }
                             if (verifyResult.isFailure) {
+                                isLinking = false
                                 error = context.getString(R.string.error_wrong_pin)
                                 return@launch
                             }
@@ -1060,16 +1064,17 @@ private fun LinkBiometricDialog(
                             // PIN verified, now link biometric
                             val activity = getActivity()
                             if (activity == null) {
+                                isLinking = false
                                 error = "ACTIVITY_NOT_AVAILABLE"
                                 return@launch
                             }
 
                             if (!BiometricUtils.canAuthenticate(activity)) {
+                                isLinking = false
                                 error = context.getString(R.string.error_biometric_not_available)
                                 return@launch
                             }
 
-                            isLinking = true
                             biometricStorage.storePin(
                                 activity = activity,
                                 pin = pin,

--- a/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
@@ -1069,7 +1069,9 @@ private fun LinkBiometricDialog(
                                 return@launch
                             }
 
-                            if (!BiometricUtils.canAuthenticate(activity)) {
+                            // Use stricter check matching BiometricPinStorage requirement (BIOMETRIC_STRONG only)
+                            // BiometricUtils allows DEVICE_CREDENTIAL fallback which won't work with hardware-backed keys
+                            if (!biometricStorage.canAuthenticate(activity)) {
                                 isLinking = false
                                 error = context.getString(R.string.error_biometric_not_available)
                                 return@launch

--- a/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -49,6 +50,7 @@ import androidx.compose.ui.unit.sp
 import com.lockit.LockitApp
 import com.lockit.R
 import com.lockit.data.database.LockitDatabase
+import com.lockit.data.biometric.BiometricPinStorage
 import com.lockit.data.sync.GoogleDriveSyncManager
 import com.lockit.data.updater.AppUpdater
 import com.lockit.data.updater.GitHubRelease
@@ -70,6 +72,8 @@ import com.lockit.ui.theme.ThemeMode
 import com.lockit.ui.theme.ThemePreference
 import com.lockit.ui.theme.White
 import com.lockit.utils.LocaleHelper
+import com.lockit.utils.BiometricUtils
+import androidx.fragment.app.FragmentActivity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -86,9 +90,24 @@ fun ConfigScreen(
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
+    val view = LocalView.current
+
+    fun getActivity(): FragmentActivity? {
+        var ctx = view.context
+        while (ctx is android.content.ContextWrapper) {
+            if (ctx is FragmentActivity) return ctx
+            ctx = ctx.baseContext
+        }
+        return null
+    }
 
     var showChangePinDialog by remember { mutableStateOf(false) }
+    var showLinkBiometricDialog by remember { mutableStateOf(false) }
     var toastMessage by remember { mutableStateOf<String?>(null) }
+
+    // Biometric status
+    val biometricStorage = remember { BiometricPinStorage(context.getSharedPreferences("lockit_biometric_prefs", android.content.Context.MODE_PRIVATE)) }
+    var isBiometricLinked by remember { mutableStateOf(biometricStorage.isBiometricLinked()) }
 
     // App update
     val appUpdater = remember { AppUpdater(context) }
@@ -152,6 +171,23 @@ fun ConfigScreen(
             onSuccess = {
                 showChangePinDialog = false
                 toastMessage = context.getString(R.string.toast_password_changed)
+            },
+        )
+    }
+
+    if (showLinkBiometricDialog) {
+        LinkBiometricDialog(
+            app = app,
+            biometricStorage = biometricStorage,
+            onDismiss = { showLinkBiometricDialog = false },
+            onSuccess = {
+                showLinkBiometricDialog = false
+                isBiometricLinked = true
+                toastMessage = context.getString(R.string.toast_biometric_linked)
+            },
+            onError = { err ->
+                showLinkBiometricDialog = false
+                toastMessage = err
             },
         )
     }
@@ -257,6 +293,16 @@ fun ConfigScreen(
 
             Spacer(modifier = Modifier.height(24.dp))
 
+            // Biometric Status Section
+            ConfigSection(
+                title = stringResource(R.string.config_biometric_status),
+                items = listOf(
+                    stringResource(R.string.config_biometric_linked) to if (isBiometricLinked) stringResource(R.string.config_yes) else stringResource(R.string.config_no),
+                ),
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
             // Actions Section
             ConfigSection(
                 title = stringResource(R.string.config_actions),
@@ -280,6 +326,31 @@ fun ConfigScreen(
                             modifier = Modifier.fillMaxWidth(),
                             useMonoFont = true,
                         )
+                        // Biometric button - show link or unlink based on state
+                        if (isBiometricLinked) {
+                            BrutalistButton(
+                                text = stringResource(R.string.config_unlink_biometric),
+                                onClick = {
+                                    // Use unlink() to only remove encrypted PIN, preserve prompt tracker
+                                    biometricStorage.unlink()
+                                    isBiometricLinked = false
+                                    toastMessage = context.getString(R.string.toast_biometric_unlinked)
+                                },
+                                variant = ButtonVariant.Danger,
+                                modifier = Modifier.fillMaxWidth(),
+                                useMonoFont = true,
+                            )
+                        } else {
+                            BrutalistButton(
+                                text = stringResource(R.string.config_link_biometric),
+                                onClick = {
+                                    showLinkBiometricDialog = true
+                                },
+                                variant = ButtonVariant.Primary,
+                                modifier = Modifier.fillMaxWidth(),
+                                useMonoFont = true,
+                            )
+                        }
                         BrutalistButton(
                             text = stringResource(R.string.config_export_keys),
                             onClick = {
@@ -882,6 +953,143 @@ private fun ChangePasswordDialog(
                     modifier = Modifier.weight(1f),
                     useMonoFont = true,
                     enabled = !isUpdating,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun LinkBiometricDialog(
+    app: LockitApp,
+    biometricStorage: BiometricPinStorage,
+    onDismiss: () -> Unit,
+    onSuccess: () -> Unit,
+    onError: (String) -> Unit,
+) {
+    var pin by remember { mutableStateOf("") }
+    var error by remember { mutableStateOf<String?>(null) }
+    var isLinking by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+    val context = LocalContext.current
+    val view = LocalView.current
+
+    fun getActivity(): FragmentActivity? {
+        var ctx = view.context
+        while (ctx is android.content.ContextWrapper) {
+            if (ctx is FragmentActivity) return ctx
+            ctx = ctx.baseContext
+        }
+        return null
+    }
+
+    androidx.compose.ui.window.Dialog(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                .border(2.dp, MaterialTheme.colorScheme.primary)
+                .padding(24.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.config_link_biometric),
+                fontFamily = JetBrainsMonoFamily,
+                fontWeight = FontWeight.Bold,
+                fontSize = 14.sp,
+                color = Primary,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.config_link_biometric_desc),
+                fontFamily = JetBrainsMonoFamily,
+                fontSize = 10.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+
+            error?.let {
+                Text(
+                    text = it,
+                    fontFamily = JetBrainsMonoFamily,
+                    fontSize = 10.sp,
+                    color = TacticalRed,
+                    modifier = Modifier.border(1.dp, TacticalRed).padding(8.dp),
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+
+            BrutalistTextField(
+                value = pin,
+                onValueChange = { if (it.length <= 4) { pin = it; error = null } },
+                label = stringResource(R.string.change_pin_current),
+                placeholder = stringResource(R.string.change_pin_placeholder),
+                isPassword = true,
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                BrutalistButton(
+                    text = stringResource(R.string.btn_cancel),
+                    onClick = onDismiss,
+                    variant = ButtonVariant.Secondary,
+                    modifier = Modifier.weight(1f),
+                    useMonoFont = true,
+                )
+                BrutalistButton(
+                    text = if (isLinking) "LINKING..." else "LINK",
+                    onClick = {
+                        if (isLinking) return@BrutalistButton
+                        if (pin.length < 4) {
+                            error = context.getString(R.string.error_pin_too_short)
+                            return@BrutalistButton
+                        }
+
+                        // First verify PIN is correct
+                        scope.launch {
+                            val verifyResult = withContext(Dispatchers.IO) {
+                                app.vaultManager.unlockVault(pin)
+                            }
+                            if (verifyResult.isFailure) {
+                                error = context.getString(R.string.error_wrong_pin)
+                                return@launch
+                            }
+
+                            // PIN verified, now link biometric
+                            val activity = getActivity()
+                            if (activity == null) {
+                                error = "ACTIVITY_NOT_AVAILABLE"
+                                return@launch
+                            }
+
+                            if (!BiometricUtils.canAuthenticate(activity)) {
+                                error = context.getString(R.string.error_biometric_not_available)
+                                return@launch
+                            }
+
+                            isLinking = true
+                            biometricStorage.storePin(
+                                activity = activity,
+                                pin = pin,
+                                title = context.getString(R.string.biometric_link_pin_title),
+                                subtitle = context.getString(R.string.biometric_link_pin_subtitle),
+                                onSuccess = {
+                                    isLinking = false
+                                    onSuccess()
+                                },
+                                onError = { err ->
+                                    isLinking = false
+                                    error = err
+                                },
+                            )
+                        }
+                    },
+                    variant = ButtonVariant.Primary,
+                    modifier = Modifier.weight(1f),
+                    useMonoFont = true,
+                    enabled = !isLinking,
                 )
             }
         }

--- a/app/src/main/java/com/lockit/ui/screens/vault_unlock/VaultUnlockScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/vault_unlock/VaultUnlockScreen.kt
@@ -159,7 +159,13 @@ class VaultUnlockViewModel(private val app: LockitApp) : ViewModel() {
                             app.vaultManager.initVault(pin)
                         }
                         isProcessing = false
-                        showBiometricSetup = true
+                        // Only show biometric setup if user hasn't been prompted before
+                        if (!biometricStorage.hasBeenPromptedForBiometric()) {
+                            showBiometricSetup = true
+                        } else {
+                            // Already prompted, navigate directly
+                            _uiState.value = VaultUnlockUiState(navigated = true)
+                        }
                     } catch (e: Exception) {
                         isProcessing = false
                         errorMessage = e.message?.uppercase() ?: "INIT_FAILED"
@@ -196,6 +202,14 @@ class VaultUnlockViewModel(private val app: LockitApp) : ViewModel() {
     fun setAppState(initialized: Boolean) {
         this.isInitialized = initialized
         this.isBiometricLinked = initialized && biometricStorage.isBiometricLinked()
+    }
+
+    fun markBiometricPrompted() {
+        biometricStorage.setBiometricPrompted(true)
+    }
+
+    fun hasBeenPromptedForBiometric(): Boolean {
+        return biometricStorage.hasBeenPromptedForBiometric()
     }
 
     fun linkBiometric(
@@ -530,6 +544,7 @@ fun VaultUnlockScreen(
                         BrutalistSmallButton(
                             text = stringResource(R.string.vault_skip),
                             onClick = {
+                                viewModel.markBiometricPrompted()
                                 viewModel.showBiometricSetup = false
                                 viewModel.navigateToMain()
                             },
@@ -545,10 +560,12 @@ fun VaultUnlockScreen(
                                         title = linkTitle,
                                         subtitle = linkSubtitle,
                                         onSuccess = {
+                                            viewModel.markBiometricPrompted()
                                             viewModel.showBiometricSetup = false
                                             viewModel.navigateToMain()
                                         },
                                         onError = { err ->
+                                            viewModel.markBiometricPrompted()
                                             viewModel.errorMessage = "BIOMETRIC_LINK_FAILED: $err"
                                             viewModel.showBiometricSetup = false
                                             viewModel.navigateToMain()

--- a/app/src/main/java/com/lockit/ui/screens/vault_unlock/VaultUnlockScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/vault_unlock/VaultUnlockScreen.kt
@@ -80,11 +80,7 @@ class VaultUnlockViewModel(private val app: LockitApp) : ViewModel() {
     var isProcessing by mutableStateOf(false)
     var isInitialized by mutableStateOf(false)
     var showBiometricSetup by mutableStateOf(false)
-    var showBiometricButton by mutableStateOf(false)
-        private set
     var isBiometricLinked by mutableStateOf(false)
-        private set
-    var hasBiometricBeenPrompted by mutableStateOf(false)
         private set
 
     fun onPinDigit(digit: String) {
@@ -200,17 +196,6 @@ class VaultUnlockViewModel(private val app: LockitApp) : ViewModel() {
     fun setAppState(initialized: Boolean) {
         this.isInitialized = initialized
         this.isBiometricLinked = initialized && biometricStorage.isBiometricLinked()
-        this.hasBiometricBeenPrompted = biometricStorage.hasBeenPromptedForBiometric()
-        // Only show biometric button if: initialized AND (biometric is linked OR user hasn't been prompted yet)
-        // After prompt, don't show "Link biometric" button on unlock screen - user can manage in Settings
-        showBiometricButton = initialized && (isBiometricLinked || !hasBiometricBeenPrompted)
-    }
-
-    fun markBiometricPrompted() {
-        biometricStorage.setBiometricPrompted(true)
-        hasBiometricBeenPrompted = true
-        // Hide the button after prompting (unless biometric is linked)
-        showBiometricButton = isBiometricLinked
     }
 
     fun linkBiometric(
@@ -225,7 +210,7 @@ class VaultUnlockViewModel(private val app: LockitApp) : ViewModel() {
             return
         }
         biometricStorage.storePin(activity, pin, title, subtitle, onSuccess = {
-            showBiometricButton = true
+            isBiometricLinked = true
             onSuccess()
         }, onError = onError)
     }
@@ -546,7 +531,6 @@ fun VaultUnlockScreen(
                             text = stringResource(R.string.vault_skip),
                             onClick = {
                                 viewModel.showBiometricSetup = false
-                                viewModel.markBiometricPrompted()
                                 viewModel.navigateToMain()
                             },
                             modifier = Modifier.weight(1f),
@@ -562,13 +546,11 @@ fun VaultUnlockScreen(
                                         subtitle = linkSubtitle,
                                         onSuccess = {
                                             viewModel.showBiometricSetup = false
-                                            viewModel.markBiometricPrompted()
                                             viewModel.navigateToMain()
                                         },
                                         onError = { err ->
                                             viewModel.errorMessage = "BIOMETRIC_LINK_FAILED: $err"
                                             viewModel.showBiometricSetup = false
-                                            viewModel.markBiometricPrompted()
                                             viewModel.navigateToMain()
                                         },
                                     )

--- a/app/src/main/java/com/lockit/ui/screens/vault_unlock/VaultUnlockScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/vault_unlock/VaultUnlockScreen.kt
@@ -84,6 +84,8 @@ class VaultUnlockViewModel(private val app: LockitApp) : ViewModel() {
         private set
     var isBiometricLinked by mutableStateOf(false)
         private set
+    var hasBiometricBeenPrompted by mutableStateOf(false)
+        private set
 
     fun onPinDigit(digit: String) {
         if (isConfirmStep) {
@@ -198,7 +200,17 @@ class VaultUnlockViewModel(private val app: LockitApp) : ViewModel() {
     fun setAppState(initialized: Boolean) {
         this.isInitialized = initialized
         this.isBiometricLinked = initialized && biometricStorage.isBiometricLinked()
-        showBiometricButton = initialized
+        this.hasBiometricBeenPrompted = biometricStorage.hasBeenPromptedForBiometric()
+        // Only show biometric button if: initialized AND (biometric is linked OR user hasn't been prompted yet)
+        // After prompt, don't show "Link biometric" button on unlock screen - user can manage in Settings
+        showBiometricButton = initialized && (isBiometricLinked || !hasBiometricBeenPrompted)
+    }
+
+    fun markBiometricPrompted() {
+        biometricStorage.setBiometricPrompted(true)
+        hasBiometricBeenPrompted = true
+        // Hide the button after prompting (unless biometric is linked)
+        showBiometricButton = isBiometricLinked
     }
 
     fun linkBiometric(
@@ -408,41 +420,23 @@ fun VaultUnlockScreen(
                                     )
                                 }
                             } else {
-                                if (viewModel.isInitialized) {
-                                    val bioText = if (viewModel.isBiometricLinked)
-                                        stringResource(R.string.vault_unlock_biometric)
-                                    else
-                                        stringResource(R.string.vault_biometric_link)
-                                    val linkTitle = stringResource(R.string.biometric_link_pin_title)
-                                    val linkSubtitle = stringResource(R.string.biometric_link_pin_subtitle)
+                                if (viewModel.isInitialized && viewModel.isBiometricLinked) {
+                                    // Only show biometric button if biometric is linked
+                                    // "Link biometric" moved to Settings page
                                     val unlockTitle = stringResource(R.string.biometric_unlock_title)
                                     val unlockSubtitle = stringResource(R.string.biometric_unlock_subtitle)
                                     BrutalistActionButton(
-                                        text = bioText,
+                                        text = stringResource(R.string.vault_unlock_biometric),
                                         onClick = {
                                             val activity = view.findActivity()
                                             if (activity != null) {
-                                                if (viewModel.isBiometricLinked) {
-                                                    viewModel.authenticateWithBiometric(
-                                                        activity = activity,
-                                                        title = unlockTitle,
-                                                        subtitle = unlockSubtitle,
-                                                        onSuccess = { },
-                                                        onError = { viewModel.errorMessage = "BIOMETRIC_FAILED: $it" },
-                                                    )
-                                                } else {
-                                                    if (viewModel.pin.length >= 4) {
-                                                        viewModel.linkBiometric(
-                                                            activity = activity,
-                                                            title = linkTitle,
-                                                            subtitle = linkSubtitle,
-                                                            onSuccess = { /* linked */ },
-                                                            onError = { viewModel.errorMessage = "BIOMETRIC_LINK_FAILED: $it" },
-                                                        )
-                                                    } else {
-                                                        viewModel.errorMessage = "ENTER_PIN_FIRST_TO_LINK"
-                                                    }
-                                                }
+                                                viewModel.authenticateWithBiometric(
+                                                    activity = activity,
+                                                    title = unlockTitle,
+                                                    subtitle = unlockSubtitle,
+                                                    onSuccess = { },
+                                                    onError = { viewModel.errorMessage = "BIOMETRIC_FAILED: $it" },
+                                                )
                                             }
                                         },
                                         icon = Icons.Default.Fingerprint,
@@ -552,7 +546,7 @@ fun VaultUnlockScreen(
                             text = stringResource(R.string.vault_skip),
                             onClick = {
                                 viewModel.showBiometricSetup = false
-                                viewModel.setAppState(true)
+                                viewModel.markBiometricPrompted()
                                 viewModel.navigateToMain()
                             },
                             modifier = Modifier.weight(1f),
@@ -568,13 +562,13 @@ fun VaultUnlockScreen(
                                         subtitle = linkSubtitle,
                                         onSuccess = {
                                             viewModel.showBiometricSetup = false
-                                            viewModel.setAppState(true)
+                                            viewModel.markBiometricPrompted()
                                             viewModel.navigateToMain()
                                         },
                                         onError = { err ->
                                             viewModel.errorMessage = "BIOMETRIC_LINK_FAILED: $err"
                                             viewModel.showBiometricSetup = false
-                                            viewModel.setAppState(true)
+                                            viewModel.markBiometricPrompted()
                                             viewModel.navigateToMain()
                                         },
                                     )

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -40,6 +40,7 @@
     <string name="error_enter_pin_first">请先输入PIN</string>
     <string name="error_biometric_failed">生物识别失败:</string>
     <string name="error_biometric_link_failed">绑定失败:</string>
+    <string name="error_biometric_not_available">生物识别不可用</string>
 
     <!-- Vault Explorer Screen -->
     <string name="explorer_title">密码库浏览器</string>
@@ -72,6 +73,18 @@
     <string name="config_argon2id">ARGON2ID</string>
     <string name="config_storage">存储</string>
     <string name="config_sqlite">本地SQLite</string>
+
+    <!-- Biometric Status -->
+    <string name="config_biometric_status">生物识别状态</string>
+    <string name="config_biometric_linked">已绑定生物识别</string>
+    <string name="config_yes">是</string>
+    <string name="config_no">否</string>
+    <string name="config_link_biometric">绑定生物识别</string>
+    <string name="config_unlink_biometric">解绑生物识别</string>
+    <string name="config_link_biometric_desc">使用指纹快速解锁密码库。</string>
+    <string name="config_unlink_biometric_desc">移除指纹解锁，仅使用PIN。</string>
+    <string name="toast_biometric_linked">生物识别已绑定</string>
+    <string name="toast_biometric_unlinked">生物识别已解绑</string>
 
     <string name="config_actions">操作</string>
     <string name="config_lock_vault">锁定密码库</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,6 +40,7 @@
     <string name="error_enter_pin_first">ENTER_PIN_FIRST_TO_LINK</string>
     <string name="error_biometric_failed">BIOMETRIC_FAILED</string>
     <string name="error_biometric_link_failed">BIOMETRIC_LINK_FAILED</string>
+    <string name="error_biometric_not_available">BIOMETRIC_NOT_AVAILABLE</string>
 
     <!-- Vault Explorer Screen -->
     <string name="explorer_title">Vault Explorer</string>
@@ -72,6 +73,17 @@
     <string name="config_argon2id">ARGON2ID</string>
     <string name="config_storage">STORAGE</string>
     <string name="config_sqlite">LOCAL_SQLITE</string>
+
+    <string name="config_biometric_status">BIOMETRIC_STATUS</string>
+    <string name="config_biometric_linked">BIOMETRIC_LINKED</string>
+    <string name="config_yes">YES</string>
+    <string name="config_no">NO</string>
+    <string name="config_link_biometric">LINK_BIOMETRIC</string>
+    <string name="config_unlink_biometric">UNLINK_BIOMETRIC</string>
+    <string name="config_link_biometric_desc">Use fingerprint to unlock vault quickly.</string>
+    <string name="config_unlink_biometric_desc">Remove fingerprint unlock, use PIN only.</string>
+    <string name="toast_biometric_linked">BIOMETRIC_LINKED</string>
+    <string name="toast_biometric_unlinked">BIOMETRIC_UNLINKED</string>
 
     <string name="config_actions">ACTIONS</string>
     <string name="config_lock_vault">LOCK_VAULT</string>


### PR DESCRIPTION
## Summary
- Show biometric setup dialog only once after initial vault creation
- Remove persistent 'Link biometric' button from unlock screen after user has been prompted
- Only show 'Unlock with biometric' button if biometric is actually linked
- Move biometric management to Settings page (ConfigScreen)

## Changes
- BiometricPinStorage.kt: Add `hasBeenPromptedForBiometric()` and `setBiometricPrompted()` to track prompt state
- VaultUnlockScreen.kt: Update ViewModel to track prompt state, show biometric button only if linked
- ConfigScreen.kt: Add biometric status section and link/unlink buttons
- strings.xml: Add new biometric config strings

## Test plan
- [ ] First-time vault setup shows biometric prompt dialog
- [ ] Skipping/enabling dialog marks user as prompted
- [ ] Unlock screen shows 'Unlock with biometric' only if linked
- [ ] Settings page shows biometric status and management options

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)