### PR TITLE
fix: Bypass Google Safe Browsing WebView block (disallowed_useragent)

### DIFF
--- a/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
+++ b/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
@@ -64,6 +64,10 @@ class WebViewAuthActivity : Activity() {
             settings.javaScriptEnabled = true
             settings.domStorageEnabled = true
             settings.loadsImagesAutomatically = true
+            // Override User-Agent to mimic Chrome browser, bypassing Google Safe Browsing
+            // detection (disallowed_useragent error). WebView's default UA contains
+            // "wv" and "Mobile Safari" which triggers Google's block.
+            settings.userAgentString = "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Mobile Safari/537.36"
 
             webViewClient = AuthWebViewClient(provider, this@WebViewAuthActivity, scope)
             webChromeClient = object : WebChromeClient() {}


### PR DESCRIPTION
## Summary
- Override WebView User-Agent to mimic Chrome browser
- Bypasses Google Safe Browsing 403 error (disallowed_useragent)
- Allows Google login pages to load in WebView

## Changes
- WebViewAuthActivity.kt: Set custom User-Agent string that mimics Chrome

## Root Cause
WebView's default User-Agent contains "wv" and "Mobile Safari" identifiers that Google's Safe Browsing detects and blocks with 403 error.

## Test plan
- [ ] Build passes
- [ ] Test ChatGPT "Sign in with Google" works
- [ ] Test Qwen login still works

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)