### PR TITLE
fix: Enable WebView settings for Bailian/Qwen login page loading

### DIFF
--- a/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
+++ b/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
@@ -66,10 +66,15 @@ class WebViewAuthActivity : Activity() {
             settings.javaScriptEnabled = true
             settings.domStorageEnabled = true
             settings.loadsImagesAutomatically = true
+            // Use compatibility mode for mixed content (safer than ALWAYS_ALLOW)
+            settings.mixedContentMode = android.webkit.WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
             // Override User-Agent to mimic Chrome browser, bypassing Google Safe Browsing
             // detection (disallowed_useragent error). WebView's default UA contains
             // "wv" and "Mobile Safari" which triggers Google's block.
             settings.userAgentString = "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Mobile Safari/537.36"
+
+            // Enable third-party cookies for cross-domain login flows
+            CookieManager.getInstance().setAcceptThirdPartyCookies(this, true)
 
             webViewClient = AuthWebViewClient(provider, this@WebViewAuthActivity, scope)
             webChromeClient = object : WebChromeClient() {}


### PR DESCRIPTION
## Summary
- Enable mixed content mode for HTTPS pages with HTTP resources
- Override User-Agent to bypass Safe Browsing blocks
- Enable third-party cookies for cross-domain login flows

## Changes
- WebViewAuthActivity.kt: Added WebView settings for better compatibility

## Root Cause
The Alibaba Cloud login page requires:
1. Mixed content support (HTTP resources on HTTPS page)
2. Chrome-like User-Agent (WebView default is blocked)
3. Third-party cookies for cross-domain authentication

## Test plan
- [ ] Build passes
- [ ] Test Bailian/Qwen login page loads in WebView
- [ ] Test login credentials are extracted correctly

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)