### PR TITLE
fix: Position WebView close button below status bar

### DIFF
--- a/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
+++ b/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
@@ -12,6 +12,8 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.FrameLayout
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -100,6 +102,17 @@ class WebViewAuthActivity : Activity() {
             FrameLayout.LayoutParams.MATCH_PARENT
         ))
         rootView.addView(closeButton, closeLayout)
+
+        // Apply window insets to position close button below status bar
+        ViewCompat.setOnApplyWindowInsetsListener(rootView) { view, insets ->
+            val statusBarHeight = insets.getInsets(WindowInsetsCompat.Type.statusBars()).top
+            val density = view.context.resources.displayMetrics.density
+            val marginPx = (16 * density).toInt()  // 16dp to pixels
+            val marginTopPx = marginPx + statusBarHeight  // Add status bar height
+            closeLayout.setMargins(marginPx, marginTopPx, marginPx, marginPx)
+            closeButton.layoutParams = closeLayout
+            insets
+        }
 
         setContentView(rootView)
     }


### PR DESCRIPTION
## Summary
- Use ViewCompat WindowInsets to get status bar height
- Adjust close button top margin to include status bar height
- Prevents button from overlapping with system status bar

## Changes
- WebViewAuthActivity.kt: Added WindowInsets handling for close button positioning

## Test plan
- [ ] Build passes
- [ ] Test WebView opens on device
- [ ] Verify close button is below status bar, not overlapping

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)