### PR TITLE
feat: Direct WebView login to Bailian Coding Plan page

### DIFF
--- a/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
+++ b/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
@@ -80,10 +80,10 @@ class WebViewAuthActivity : Activity() {
             webChromeClient = object : WebChromeClient() {}
 
             val loginUrl = when (provider) {
-                "qwen_bailian" -> "https://account.aliyun.com/login.htm"
+                "qwen_bailian" -> "https://bailian.console.aliyun.com/cn-beijing/?tab=coding-plan#/efm/coding-plan-detail"
                 "chatgpt" -> "https://chatgpt.com/auth/login"
                 "claude" -> "https://claude.ai/login"
-                else -> "https://account.aliyun.com/login.htm"
+                else -> "https://bailian.console.aliyun.com/cn-beijing/?tab=coding-plan#/efm/coding-plan-detail"
             }
             loadUrl(loginUrl)
         }


### PR DESCRIPTION
## Summary
- Change qwen_bailian login URL from generic account page to direct coding-plan console URL
- Better UX: user lands directly on Coding Plan page after login

## Changes
- WebViewAuthActivity.kt: Update loginUrl for qwen_bailian provider

## Test plan
- [ ] Build passes
- [ ] Test Bailian WebView login redirects to Coding Plan page
- [ ] Credentials extracted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)