### PR TITLE
fix: WebView external app redirect for Alipay/Taobao auth

### DIFF
--- a/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
+++ b/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
@@ -242,9 +242,15 @@ class AuthWebViewClient(
             url.startsWith("weixin://") ||
             url.startsWith("sms:") ||
             url.startsWith("tel:")) {
-            val intent = Intent(Intent.ACTION_VIEW, android.net.Uri.parse(url))
-            activity.startActivity(intent)
-            return true
+            try {
+                val intent = Intent(Intent.ACTION_VIEW, android.net.Uri.parse(url))
+                activity.startActivity(intent)
+                return true
+            } catch (e: android.content.ActivityNotFoundException) {
+                // External app not installed, continue loading in WebView
+                android.widget.Toast.makeText(activity, "External app not installed", android.widget.Toast.LENGTH_SHORT).show()
+                return false
+            }
         }
 
         return false

--- a/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
+++ b/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
@@ -233,6 +233,20 @@ class AuthWebViewClient(
     }
 
     override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
+        val url = request?.url?.toString() ?: return false
+
+        // Handle external app schemes (Alipay, Taobao, WeChat, SMS, Tel)
+        if (url.startsWith("alipay://") ||
+            url.startsWith("alipays://") ||
+            url.startsWith("taobao://") ||
+            url.startsWith("weixin://") ||
+            url.startsWith("sms:") ||
+            url.startsWith("tel:")) {
+            val intent = Intent(Intent.ACTION_VIEW, android.net.Uri.parse(url))
+            activity.startActivity(intent)
+            return true
+        }
+
         return false
     }
 


### PR DESCRIPTION
## Summary
- Handle external app URL schemes (alipay://, alipays://, taobao://, weixin://, sms:, tel:)
- Launch external apps via Intent.ACTION_VIEW instead of loading in WebView
- Fixes login redirect failure when Bailian requires Alipay/Taobao authorization

## Changes
- `WebViewAuthActivity.kt` - Modify `shouldOverrideUrlLoading()` to handle external schemes

## Problem
When Bailian login page redirects to `alipay://` or `taobao://` for payment/auth, WebView tries to load these schemes internally, fails, and shows blank page. User cannot complete login.

## Solution
Detect external scheme URLs and launch the appropriate app via Intent. Return `true` to prevent WebView from loading the URL.

## Test plan
- [x] Build passes (`./gradlew assembleDebug`)
- [x] Lint passes (`./gradlew lintDebug`)
- [ ] Manual test: Login to Bailian with Alipay redirect

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)