### PR TITLE
fix: Replace !! force unwrap with safe null handling

### DIFF
--- a/app/src/main/java/com/lockit/data/crypto/KeyManager.kt
+++ b/app/src/main/java/com/lockit/data/crypto/KeyManager.kt
@@ -92,7 +92,8 @@ class KeyManager(private val context: Context) {
         val verifyKey = crypto.deriveKey(password, salt, currentMemory, currentIterations, currentParallelism)
 
         // Verify password is correct by comparing with current master key
-        if (!verifyKey.contentEquals(masterKey!!)) {
+        val currentKey = masterKey ?: throw IllegalStateException("Vault not unlocked")
+        if (!verifyKey.contentEquals(currentKey)) {
             verifyKey.fill(0)
             throw IllegalArgumentException("WRONG_PIN")
         }

--- a/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
@@ -177,7 +177,8 @@ fun ConfigScreen(
     // Load last backup time when signed in
     if (signedInAccount != null && lastBackupTime == null && !isSyncing) {
         LaunchedEffect(signedInAccount) {
-            val timeResult = syncManager.getLastBackupTime(signedInAccount!!)
+            val account = signedInAccount ?: return@LaunchedEffect
+            val timeResult = syncManager.getLastBackupTime(account)
             lastBackupTime = timeResult.getOrNull()
         }
     }
@@ -244,16 +245,17 @@ fun ConfigScreen(
     }
 
     // Update dialog - Pre-fetch string resources to avoid context usage in coroutine after UI disposal
-    if (showUpdateDialog && availableUpdate != null) {
-        val apkUrl = availableUpdate?.apkUrl
-        val versionName = availableUpdate?.versionName
-        val strDownloadComplete = context.getString(R.string.toast_download_complete)
-        val strDownloadFailed = context.getString(R.string.toast_download_failed)
-        val strDownloadStarted = context.getString(R.string.toast_download_started)
-        val strDownloadLocation = context.getString(R.string.toast_download_location)
-        val strNoApkUrl = context.getString(R.string.toast_no_apk_url)
-        UpdateDialog(
-            release = availableUpdate!!,
+    availableUpdate?.let { release ->
+        if (showUpdateDialog) {
+            val apkUrl = release.apkUrl
+            val versionName = release.versionName
+            val strDownloadComplete = context.getString(R.string.toast_download_complete)
+            val strDownloadFailed = context.getString(R.string.toast_download_failed)
+            val strDownloadStarted = context.getString(R.string.toast_download_started)
+            val strDownloadLocation = context.getString(R.string.toast_download_location)
+            val strNoApkUrl = context.getString(R.string.toast_no_apk_url)
+            UpdateDialog(
+                release = release,
             onDismiss = { showUpdateDialog = false },
             onDownload = {
                 if (apkUrl == null) {
@@ -296,7 +298,8 @@ fun ConfigScreen(
                     }
                 }
             },
-        )
+            )
+        }
     }
 
     // GitHub Token config dialog
@@ -477,16 +480,17 @@ fun ConfigScreen(
                         BrutalistButton(
                             text = if (signedInAccount == null) stringResource(R.string.config_sign_in_google) else stringResource(R.string.config_sync_drive),
                             onClick = {
-                                if (signedInAccount == null) {
+                                val account = signedInAccount
+                                if (account == null) {
                                     signInLauncher.launch(syncManager.getSignInIntent())
                                 } else {
-                                    syncToDrive(app, syncManager, signedInAccount!!, context, scope) { error ->
+                                    syncToDrive(app, syncManager, account, context, scope) { error ->
                                         if (error != null) {
                                             toastMessage = error
                                         } else {
                                             toastMessage = context.getString(R.string.toast_sync_complete)
                                             scope.launch {
-                                                val timeResult = syncManager.getLastBackupTime(signedInAccount!!)
+                                                val timeResult = syncManager.getLastBackupTime(account)
                                                 lastBackupTime = timeResult.getOrNull()
                                             }
                                         }

--- a/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
@@ -526,12 +526,11 @@ fun ReposScreen(
                 )
             }
 
-            if (selectedCredential != null) {
+            selectedCredential?.let { cred ->
                 CredentialCardModal(
-                    credential = selectedCredential!!,
+                    credential = cred,
                     onDismiss = { selectedCredential = null },
                     onCopy = { action ->
-                        val cred = selectedCredential!!
                         val fields = parseCredentialFields(cred.value)
                         val valueToCopy = when (action) {
                             CopyAction.VALUE -> extractSecretValue(cred.type, cred.value)
@@ -545,14 +544,13 @@ fun ReposScreen(
                         viewModel.logCredentialCopied(cred.name)
                     },
                     onDelete = {
-                        val cred = selectedCredential!!
                         scope.launch {
                             app.vaultManager.deleteCredential(cred)
                         }
                         selectedCredential = null
                     },
                     onEdit = {
-                        onCredentialEdit(selectedCredential!!.id)
+                        onCredentialEdit(cred.id)
                         selectedCredential = null
                     },
                     onNeedReveal = { },
@@ -577,7 +575,7 @@ fun ReposScreen(
                 )
 
                 ScreenHero(
-                    title = selectedService!!.uppercase(),
+                    title = selectedService?.uppercase() ?: "UNKNOWN",
                     subtitle = when {
                         isPhone -> stringResource(R.string.repos_phone_subtitle)
                         isCodingPlan -> stringResource(R.string.repos_coding_plan_subtitle)

--- a/app/src/main/java/com/lockit/ui/screens/secret_details/SecretDetailsScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/secret_details/SecretDetailsScreen.kt
@@ -102,22 +102,24 @@ fun SecretDetailsScreen(
         }
     }
 
-    if (showDeleteDialog && credential != null) {
-        BrutalistConfirmDialog(
-            title = "DELETE CREDENTIAL",
-            message = "Permanently delete \"${credential!!.name}\"? This action cannot be undone.",
-            confirmText = "DELETE",
-            onConfirm = {
-                showDeleteDialog = false
-                scope.launch {
-                    app.vaultManager.deleteCredential(credential!!)
-                    toastMessage = "CREDENTIAL_DELETED: ${credential!!.name}"
-                    kotlinx.coroutines.delay(500)
-                    onDelete()
-                }
-            },
-            onDismiss = { showDeleteDialog = false },
-        )
+    if (showDeleteDialog) {
+        credential?.let { credToDelete ->
+            BrutalistConfirmDialog(
+                title = "DELETE CREDENTIAL",
+                message = "Permanently delete \"${credToDelete.name}\"? This action cannot be undone.",
+                confirmText = "DELETE",
+                onConfirm = {
+                    showDeleteDialog = false
+                    scope.launch {
+                        app.vaultManager.deleteCredential(credToDelete)
+                        toastMessage = "CREDENTIAL_DELETED: ${credToDelete.name}"
+                        kotlinx.coroutines.delay(500)
+                        onDelete()
+                    }
+                },
+                onDismiss = { showDeleteDialog = false },
+            )
+        }
     }
 
     if (isLoading) {


### PR DESCRIPTION
## Summary
- Replace all !! force unwrap operators with safe null handling patterns
- Use ?.let {} for nullable state in Composable dialogs
- Use ?: throw with descriptive message for non-null expectations
- Eliminate NPE crash risks without changing behavior

## Changes
- `ConfigScreen.kt`: Safe local variable for signedInAccount, ?.let for availableUpdate
- `ReposScreen.kt`: ?.let for selectedCredential, ?.uppercase() fallback for selectedService
- `SecretDetailsScreen.kt`: ?.let for credential in delete dialog
- `KeyManager.kt`: ?: throw IllegalStateException for masterKey

## Files Fixed
| File | !! Count | Fix Pattern |
|------|----------|-------------|
| ConfigScreen.kt | 4 | ?: local var, ?.let |
| ReposScreen.kt | 6 | ?.let { cred -> } |
| SecretDetailsScreen.kt | 3 | ?.let { cred -> } |
| KeyManager.kt | 1 | ?: throw |

## Test plan
- [x] Build passes (`./gradlew assembleDebug`)
- [x] Lint passes (`./gradlew lintDebug`)

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)