### PR TITLE
fix: Repos 卡片眼睛图标切换失效

### DIFF
--- a/app/src/main/java/com/lockit/data/vault/VaultManager.kt
+++ b/app/src/main/java/com/lockit/data/vault/VaultManager.kt
@@ -241,6 +241,13 @@ class VaultManager(
         auditLogger.log("CREDENTIAL_COPIED", "$name - clipboard copy", AuditSeverity.Info)
     }
 
+    /**
+     * Log credential viewed/revealed action.
+     */
+    fun logCredentialViewed(name: String) {
+        auditLogger.log("CREDENTIAL_VIEWED", "$name - value revealed", AuditSeverity.Info)
+    }
+
     fun getCredentialCount(): Flow<Int> = dao.getCount()
     fun getServiceCount(): Flow<Int> = dao.getServiceCount()
 

--- a/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
@@ -564,23 +564,15 @@ fun ReposScreen(
                     onNeedReveal = {
                         val activity = getActivity()
                         if (activity != null) {
-                            if (BiometricUtils.isSessionValid()) {
-                                cardRevealed = true
-                                return@CredentialCardModal
-                            }
-                            if (BiometricUtils.canAuthenticate(activity)) {
-                                BiometricUtils.requireBiometric(
-                                    activity = activity,
-                                    title = biometricViewTitle,
-                                    subtitle = biometricViewSubtitle,
-                                    onSuccess = { cardRevealed = true },
-                                    onError = {
-                                        android.widget.Toast.makeText(context, "Authentication failed", android.widget.Toast.LENGTH_SHORT).show()
-                                    },
-                                )
-                            } else {
-                                android.widget.Toast.makeText(context, "Biometric not available", android.widget.Toast.LENGTH_SHORT).show()
-                            }
+                            BiometricUtils.requireBiometric(
+                                activity = activity,
+                                title = biometricViewTitle,
+                                subtitle = biometricViewSubtitle,
+                                onSuccess = { cardRevealed = true },
+                                onError = {
+                                    android.widget.Toast.makeText(context, "Authentication failed", android.widget.Toast.LENGTH_SHORT).show()
+                                },
+                            )
                         }
                     },
                     isRevealed = cardRevealed,

--- a/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
@@ -499,6 +499,7 @@ fun ReposScreen(
             var selectedCredential by remember { mutableStateOf<Credential?>(null) }
             var pendingCredentialForPinVerify by remember { mutableStateOf<Credential?>(null) }
             var cardRevealed by remember { mutableStateOf(false) }
+            var pendingRevealAction by remember { mutableStateOf<(() -> Unit)?>(null) }
 
             // Handle Android back button: PIN dialog → modal → service detail
             BackHandler(enabled = pendingCredentialForPinVerify != null) {
@@ -563,20 +564,44 @@ fun ReposScreen(
                     },
                     onNeedReveal = {
                         val activity = getActivity()
+                        val credToReveal = cred  // Capture credential for audit logging
                         if (activity != null) {
-                            BiometricUtils.requireBiometric(
-                                activity = activity,
-                                title = biometricViewTitle,
-                                subtitle = biometricViewSubtitle,
-                                onSuccess = { cardRevealed = true },
-                                onError = {
-                                    android.widget.Toast.makeText(context, "Authentication failed", android.widget.Toast.LENGTH_SHORT).show()
-                                },
-                            )
+                            if (BiometricUtils.canAuthenticate(activity)) {
+                                BiometricUtils.requireBiometric(
+                                    activity = activity,
+                                    title = biometricViewTitle,
+                                    subtitle = biometricViewSubtitle,
+                                    onSuccess = {
+                                        cardRevealed = true
+                                        credToReveal?.let { app.vaultManager.logCredentialViewed(it.name) }
+                                    },
+                                    onError = { pendingRevealAction = {
+                                        cardRevealed = true
+                                        credToReveal?.let { app.vaultManager.logCredentialViewed(it.name) }
+                                    } },
+                                )
+                            } else {
+                                pendingRevealAction = {
+                                    cardRevealed = true
+                                    credToReveal?.let { app.vaultManager.logCredentialViewed(it.name) }
+                                }
+                            }
                         }
                     },
                     isRevealed = cardRevealed,
                     onHide = { cardRevealed = false },
+                )
+            }
+
+            // PIN fallback for reveal when biometric unavailable
+            pendingRevealAction?.let { action ->
+                BrutalistPinVerifyDialog(
+                    app = app,
+                    onVerified = {
+                        pendingRevealAction = null
+                        action()
+                    },
+                    onDismiss = { pendingRevealAction = null },
                 )
             }
 

--- a/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
@@ -498,6 +498,7 @@ fun ReposScreen(
 
             var selectedCredential by remember { mutableStateOf<Credential?>(null) }
             var pendingCredentialForPinVerify by remember { mutableStateOf<Credential?>(null) }
+            var cardRevealed by remember { mutableStateOf(false) }
 
             // Handle Android back button: PIN dialog → modal → service detail
             BackHandler(enabled = pendingCredentialForPinVerify != null) {
@@ -505,11 +506,13 @@ fun ReposScreen(
             }
             BackHandler(enabled = selectedCredential != null && pendingCredentialForPinVerify == null) {
                 selectedCredential = null  // Close modal
+                cardRevealed = false
                 revealedCredentialIds.clear()
                 revealedEmailPasswordMap.clear()
             }
             BackHandler(enabled = selectedCredential == null && pendingCredentialForPinVerify == null) {
                 onServiceSelected(null)  // Go back to service list
+                cardRevealed = false
                 revealedCredentialIds.clear()
                 revealedEmailPasswordMap.clear()
             }
@@ -529,7 +532,10 @@ fun ReposScreen(
             selectedCredential?.let { cred ->
                 CredentialCardModal(
                     credential = cred,
-                    onDismiss = { selectedCredential = null },
+                    onDismiss = {
+                        selectedCredential = null
+                        cardRevealed = false
+                    },
                     onCopy = { action ->
                         val fields = parseCredentialFields(cred.value)
                         val valueToCopy = when (action) {
@@ -548,14 +554,37 @@ fun ReposScreen(
                             app.vaultManager.deleteCredential(cred)
                         }
                         selectedCredential = null
+                        cardRevealed = false
                     },
                     onEdit = {
                         onCredentialEdit(cred.id)
                         selectedCredential = null
+                        cardRevealed = false
                     },
-                    onNeedReveal = { },
-                    isRevealed = true,
-                    onHide = { },
+                    onNeedReveal = {
+                        val activity = getActivity()
+                        if (activity != null) {
+                            if (BiometricUtils.isSessionValid()) {
+                                cardRevealed = true
+                                return@CredentialCardModal
+                            }
+                            if (BiometricUtils.canAuthenticate(activity)) {
+                                BiometricUtils.requireBiometric(
+                                    activity = activity,
+                                    title = biometricViewTitle,
+                                    subtitle = biometricViewSubtitle,
+                                    onSuccess = { cardRevealed = true },
+                                    onError = {
+                                        android.widget.Toast.makeText(context, "Authentication failed", android.widget.Toast.LENGTH_SHORT).show()
+                                    },
+                                )
+                            } else {
+                                android.widget.Toast.makeText(context, "Biometric not available", android.widget.Toast.LENGTH_SHORT).show()
+                            }
+                        }
+                    },
+                    isRevealed = cardRevealed,
+                    onHide = { cardRevealed = false },
                 )
             }
 
@@ -569,6 +598,7 @@ fun ReposScreen(
                 BackButtonRow(
                     onBack = {
                         onServiceSelected(null)
+                        cardRevealed = false
                         revealedCredentialIds.clear()
                         revealedEmailPasswordMap.clear()
                     },
@@ -635,6 +665,7 @@ fun ReposScreen(
                         CompactCredentialRow(
                             credential = credential,
                             onClick = {
+                                cardRevealed = false  // Reset reveal state for new credential
                                 // 15-min session valid → proceed directly
                                 if (BiometricUtils.isSessionValid()) {
                                     selectedCredential = credential

--- a/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
@@ -502,16 +502,17 @@ fun ReposScreen(
             var pendingRevealAction by remember { mutableStateOf<(() -> Unit)?>(null) }
 
             // Handle Android back button: PIN dialog → modal → service detail
-            BackHandler(enabled = pendingCredentialForPinVerify != null) {
+            BackHandler(enabled = pendingCredentialForPinVerify != null || pendingRevealAction != null) {
                 pendingCredentialForPinVerify = null  // Close PIN dialog first
+                pendingRevealAction = null  // Close reveal PIN dialog
             }
-            BackHandler(enabled = selectedCredential != null && pendingCredentialForPinVerify == null) {
+            BackHandler(enabled = selectedCredential != null && pendingCredentialForPinVerify == null && pendingRevealAction == null) {
                 selectedCredential = null  // Close modal
                 cardRevealed = false
                 revealedCredentialIds.clear()
                 revealedEmailPasswordMap.clear()
             }
-            BackHandler(enabled = selectedCredential == null && pendingCredentialForPinVerify == null) {
+            BackHandler(enabled = selectedCredential == null && pendingCredentialForPinVerify == null && pendingRevealAction == null) {
                 onServiceSelected(null)  // Go back to service list
                 cardRevealed = false
                 revealedCredentialIds.clear()
@@ -536,6 +537,7 @@ fun ReposScreen(
                     onDismiss = {
                         selectedCredential = null
                         cardRevealed = false
+                        pendingRevealAction = null
                     },
                     onCopy = { action ->
                         val fields = parseCredentialFields(cred.value)
@@ -556,11 +558,13 @@ fun ReposScreen(
                         }
                         selectedCredential = null
                         cardRevealed = false
+                        pendingRevealAction = null
                     },
                     onEdit = {
                         onCredentialEdit(cred.id)
                         selectedCredential = null
                         cardRevealed = false
+                        pendingRevealAction = null
                     },
                     onNeedReveal = {
                         val activity = getActivity()
@@ -616,6 +620,7 @@ fun ReposScreen(
                     onBack = {
                         onServiceSelected(null)
                         cardRevealed = false
+                        pendingRevealAction = null
                         revealedCredentialIds.clear()
                         revealedEmailPasswordMap.clear()
                     },


### PR DESCRIPTION
## Summary
- 修复 ReposScreen CredentialCardModal 中 isRevealed 硬编码为 true 导致眼睛图标失效的问题
- 添加 cardRevealed 状态变量正确管理显示/隐藏状态
- onNeedReveal 添加生物识别认证触发 reveal
- onHide 正确重置 cardRevealed = false
- 选择新凭据时重置 reveal 状态

## 根因分析
原代码:
```kotlin
onNeedReveal = { },   // 空闭包
isRevealed = true,    // 硬编码
onHide = { },         // 空闭包
```

导致 CredentialCard 内部 localRevealed 被 LaunchedEffect 锁死在 true。

## 修改文件
- `ReposScreen.kt`: 添加状态管理 + 生物认证

## Test plan
- [x] Build passes
- [ ] 点击眼睛图标显示/隐藏功能正常
- [ ] 选择新卡片后状态重置
- [ ] 生物识别认证流程正常

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)