### PR TITLE
fix: 设置中配置生物识别闪退

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
+    <!-- For API 26-29 backward compatibility with androidx.biometric -->
+    <uses-permission android:name="android.permission.USE_FINGERPRINT" />
 
     <application
         android:name=".LockitApp"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+    <uses-permission android:name="android.permission.USE_BIOMETRIC" />
 
     <application
         android:name=".LockitApp"

--- a/app/src/main/java/com/lockit/data/biometric/BiometricPinStorage.kt
+++ b/app/src/main/java/com/lockit/data/biometric/BiometricPinStorage.kt
@@ -174,6 +174,7 @@ class BiometricPinStorage(private val sharedPreferences: SharedPreferences) {
             .setTitle(title)
             .setSubtitle(subtitle)
             .setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG)
+            .setNegativeButtonText("取消")
             .build()
 
         biometricPrompt.authenticate(promptInfo, BiometricPrompt.CryptoObject(cipher))
@@ -247,6 +248,7 @@ class BiometricPinStorage(private val sharedPreferences: SharedPreferences) {
             .setTitle(title)
             .setSubtitle(subtitle)
             .setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG)
+            .setNegativeButtonText("取消")
             .build()
 
         biometricPrompt.authenticate(promptInfo, BiometricPrompt.CryptoObject(cipher))


### PR DESCRIPTION
## Summary
- 添加 USE_BIOMETRIC 权限到 AndroidManifest.xml
- BiometricPinStorage.kt 两处添加 setNegativeButtonText("取消")

## 根因分析
1. AndroidManifest.xml 缺少 USE_BIOMETRIC 权限导致 BiometricManager 无法正常工作
2. Android API 28+ 要求 BiometricPrompt.PromptInfo 必须有 negative button text (当使用 BIOMETRIC_STRONG 时)

## 修改文件
- `AndroidManifest.xml`: 添加 USE_BIOMETRIC 权限
- `BiometricPinStorage.kt`: storePin 和 decryptPin 两处添加 setNegativeButtonText

## Test plan
- [x] Build passes
- [ ] 设置中生物识别配置不再闪退
- [ ] 生物识别认证流程正常

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)