### PR TITLE
refactor: CodingPlan 字段索引常量定义

### DIFF
--- a/app/src/main/java/com/lockit/domain/model/CodingPlanFields.kt
+++ b/app/src/main/java/com/lockit/domain/model/CodingPlanFields.kt
@@ -1,0 +1,15 @@
+package com.lockit.domain.model
+
+/**
+ * Constants for CodingPlan credential field indices.
+ * All reads and writes should use these constants to prevent silent data corruption.
+ */
+object CodingPlanFields {
+    const val PROVIDER = 0   // Provider name (e.g., "qwen_bailian", "openai")
+    const val RAW_CURL = 1   // Raw curl command for auth extraction
+    const val API_KEY = 2    // API key / access token
+    const val COOKIE = 3     // Cookie string (for some providers)
+    const val BASE_URL = 4   // Base URL for API calls
+
+    const val FIELD_COUNT = 5
+}

--- a/app/src/main/java/com/lockit/ui/components/CredentialCard.kt
+++ b/app/src/main/java/com/lockit/ui/components/CredentialCard.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.platform.ClipboardManager
 import androidx.compose.ui.platform.LocalClipboardManager
 import com.lockit.domain.model.Credential
 import com.lockit.domain.model.CredentialType
+import com.lockit.domain.model.CodingPlanFields
 import com.lockit.ui.theme.IndustrialOrange
 import com.lockit.ui.theme.JetBrainsMonoFamily
 import com.lockit.ui.theme.Primary
@@ -148,7 +149,7 @@ fun extractSecretValue(type: CredentialType, value: String): String {
         CredentialType.IdCard, CredentialType.Note -> value
         CredentialType.CodingPlan -> {
             val fields = parseCredentialFields(value)
-            fields.getNotBlank(1) ?: fields.getNotBlank(2) ?: value
+            fields.getNotBlank(CodingPlanFields.RAW_CURL) ?: fields.getNotBlank(CodingPlanFields.API_KEY) ?: value
         }
         CredentialType.GitHub -> {
             val fields = parseCredentialFields(value)
@@ -450,8 +451,8 @@ private fun CredentialContent(
 
         CredentialType.CodingPlan -> {
             // CodingPlan: BASE_URL first, then API_KEY below
-            val apiKey = fields.getNotBlank(2) ?: CredentialDefaults.FIELD_NOT_SET
-            val baseUrl = fields.getNotBlank(4) ?: CredentialDefaults.FIELD_NOT_SET
+            val apiKey = fields.getNotBlank(CodingPlanFields.API_KEY) ?: CredentialDefaults.FIELD_NOT_SET
+            val baseUrl = fields.getNotBlank(CodingPlanFields.BASE_URL) ?: CredentialDefaults.FIELD_NOT_SET
 
             // BASE_URL - always visible, shown first at top
             FieldLabel("BASE_URL")

--- a/app/src/main/java/com/lockit/ui/screens/add_credential/AddCredentialScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/add_credential/AddCredentialScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.unit.sp
 import com.lockit.LockitApp
 import com.lockit.R
 import com.lockit.domain.model.CredentialType
+import com.lockit.domain.model.CodingPlanFields
 import com.lockit.domain.model.requiredFieldIndices
 import com.lockit.ui.components.BackButtonRow
 import com.lockit.ui.components.BrutalistButton
@@ -228,42 +229,42 @@ fun AddCredentialScreen(
                     fieldValues[i] = ""
                 }
 
-                // Fill in provider name (field 0)
+                // Fill in provider name
                 val provider = dataMap["provider"] ?: selectedAuthProvider
-                fieldValues[0] = provider
+                fieldValues[CodingPlanFields.PROVIDER] = provider
                 userEditedName = true
 
                 // Fill in credentials based on provider
                 when (provider) {
                     "qwen", "qwen_bailian" -> {
                         // Fill RAW_CURL
-                        fieldValues[1] = dataMap["rawCurl"] ?: ""
-                        // Fill API_KEY (direct assignment, not ?.let)
-                        fieldValues[2] = dataMap["apiKey"] ?: ""
+                        fieldValues[CodingPlanFields.RAW_CURL] = dataMap["rawCurl"] ?: ""
+                        // Fill API_KEY
+                        fieldValues[CodingPlanFields.API_KEY] = dataMap["apiKey"] ?: ""
                         // Fill COOKIE
-                        fieldValues[3] = dataMap["cookie"] ?: ""
+                        fieldValues[CodingPlanFields.COOKIE] = dataMap["cookie"] ?: ""
                         // Fill BASE_URL
-                        fieldValues[4] = dataMap["baseUrl"] ?: ""
+                        fieldValues[CodingPlanFields.BASE_URL] = dataMap["baseUrl"] ?: ""
                         // Store extra fields for metadata
                         authExtraData = dataMap
                         android.util.Log.d("AddCredential", "Bailian: apiKey=${if (dataMap["apiKey"]?.isNotBlank() == true) "OK" else "EMPTY"}")
-                        android.util.Log.d("AddCredential", "fieldValues after fill: provider=${fieldValues[0]}")
+                        android.util.Log.d("AddCredential", "fieldValues after fill: provider=${fieldValues[CodingPlanFields.PROVIDER]}")
                     }
                     "openai", "chatgpt" -> {
-                        // apiKey (accessToken) fills API_KEY field
-                        fieldValues[2] = dataMap["apiKey"] ?: ""
+                        // apiKey fills API_KEY field
+                        fieldValues[CodingPlanFields.API_KEY] = dataMap["apiKey"] ?: ""
                         // Fill BASE_URL
-                        fieldValues[4] = dataMap["baseUrl"] ?: ""
-                        // Store extra fields (accountId) for metadata
+                        fieldValues[CodingPlanFields.BASE_URL] = dataMap["baseUrl"] ?: ""
+                        // Store extra fields for metadata
                         authExtraData = dataMap
                         android.util.Log.d("AddCredential", "ChatGPT: apiKey=${if (dataMap["apiKey"]?.isNotBlank() == true) "OK" else "EMPTY"}")
                     }
                     "anthropic", "claude" -> {
-                        // apiKey (sessionKey) fills API_KEY field
-                        fieldValues[2] = dataMap["apiKey"] ?: ""
+                        // apiKey fills API_KEY field
+                        fieldValues[CodingPlanFields.API_KEY] = dataMap["apiKey"] ?: ""
                         // Fill BASE_URL
-                        fieldValues[4] = dataMap["baseUrl"] ?: ""
-                        // Store extra fields (orgId) for metadata
+                        fieldValues[CodingPlanFields.BASE_URL] = dataMap["baseUrl"] ?: ""
+                        // Store extra fields for metadata
                         authExtraData = dataMap
                         android.util.Log.d("AddCredential", "Claude: apiKey=${if (dataMap["apiKey"]?.isNotBlank() == true) "OK" else "EMPTY"}")
                     }
@@ -354,22 +355,22 @@ fun AddCredentialScreen(
 
     /** Auto-extract all fields from RAW_CURL for CodingPlan */
     fun handleRawCurlChange(value: String) {
-        fieldValues[1] = value
+        fieldValues[CodingPlanFields.RAW_CURL] = value
         if (selectedType == CredentialType.CodingPlan) {
-            // Extract cookie (index 3)
+            // Extract cookie
             val extractedCookie = extractCookieFromCurl(value)
             if (!userEditedCookie && extractedCookie.isNotBlank()) {
-                fieldValues[3] = extractedCookie
+                fieldValues[CodingPlanFields.COOKIE] = extractedCookie
             }
-            // Extract API key (index 2)
+            // Extract API key
             val extractedApiKey = extractApiKeyFromCurl(value)
             if (extractedApiKey.isNotBlank()) {
-                fieldValues[2] = extractedApiKey
+                fieldValues[CodingPlanFields.API_KEY] = extractedApiKey
             }
-            // Extract base URL (index 4)
+            // Extract base URL
             val extractedBaseUrl = extractBaseUrlFromCurl(value)
             if (extractedBaseUrl.isNotBlank()) {
-                fieldValues[4] = extractedBaseUrl
+                fieldValues[CodingPlanFields.BASE_URL] = extractedBaseUrl
             }
         }
     }

--- a/app/src/main/java/com/lockit/ui/screens/edit_credential/EditCredentialScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/edit_credential/EditCredentialScreen.kt
@@ -37,6 +37,7 @@ import com.lockit.LockitApp
 import com.lockit.R
 import com.lockit.domain.model.Credential
 import com.lockit.domain.model.CredentialType
+import com.lockit.domain.model.CodingPlanFields
 import com.lockit.domain.model.requiredFieldIndices
 import com.lockit.ui.components.BackButtonRow
 import com.lockit.ui.components.BrutalistButton
@@ -139,11 +140,11 @@ private fun EditCredentialForm(
             val baseUrl = meta?.optString("baseUrl")
 
             mutableStateListOf(
-                credential.name,                                          // 0: PROVIDER
-                if (rawCurl?.isNotBlank() == true) rawCurl else fields.getOrElse(1) { "" },  // 1: RAW_CURL
-                fields.getOrElse(2) { "" },                               // 2: API_KEY
-                if (cookie?.isNotBlank() == true) cookie else fields.getOrElse(3) { "" },    // 3: COOKIE
-                if (baseUrl?.isNotBlank() == true) baseUrl else fields.getOrElse(4) { "" },  // 4: BASE_URL
+                credential.name,                                           // PROVIDER
+                if (rawCurl?.isNotBlank() == true) rawCurl else fields.getOrElse(CodingPlanFields.RAW_CURL) { "" },  // RAW_CURL
+                fields.getOrElse(CodingPlanFields.API_KEY) { "" },        // API_KEY
+                if (cookie?.isNotBlank() == true) cookie else fields.getOrElse(CodingPlanFields.COOKIE) { "" },     // COOKIE
+                if (baseUrl?.isNotBlank() == true) baseUrl else fields.getOrElse(CodingPlanFields.BASE_URL) { "" }, // BASE_URL
             )
         } else {
             // For non-CodingPlan types: parse combined value into individual fields
@@ -196,30 +197,30 @@ private fun EditCredentialForm(
                     fieldValues[i] = ""
                 }
 
-                // Set provider field (field 0) based on returned provider
+                // Set provider field based on returned provider
                 val provider = dataMap["provider"] ?: ""
                 if (provider.isNotBlank()) {
-                    fieldValues[0] = provider
+                    fieldValues[CodingPlanFields.PROVIDER] = provider
                 }
 
-                // Fill in credentials based on provider (direct assignment)
+                // Fill in credentials based on provider
                 when (provider) {
                     "qwen", "qwen_bailian" -> {
-                        fieldValues[1] = dataMap["rawCurl"] ?: ""
-                        fieldValues[2] = dataMap["apiKey"] ?: ""
-                        fieldValues[3] = dataMap["cookie"] ?: ""
-                        fieldValues[4] = dataMap["baseUrl"] ?: ""
+                        fieldValues[CodingPlanFields.RAW_CURL] = dataMap["rawCurl"] ?: ""
+                        fieldValues[CodingPlanFields.API_KEY] = dataMap["apiKey"] ?: ""
+                        fieldValues[CodingPlanFields.COOKIE] = dataMap["cookie"] ?: ""
+                        fieldValues[CodingPlanFields.BASE_URL] = dataMap["baseUrl"] ?: ""
                         android.util.Log.d("EditCredential", "Bailian: apiKey=${if (dataMap["apiKey"]?.isNotBlank() == true) "OK" else "EMPTY"}")
-                        android.util.Log.d("EditCredential", "fieldValues after fill: provider=${fieldValues[0]}")
+                        android.util.Log.d("EditCredential", "fieldValues after fill: provider=${fieldValues[CodingPlanFields.PROVIDER]}")
                     }
                     "openai", "chatgpt" -> {
-                        fieldValues[2] = dataMap["apiKey"] ?: ""
-                        fieldValues[4] = dataMap["baseUrl"] ?: ""
+                        fieldValues[CodingPlanFields.API_KEY] = dataMap["apiKey"] ?: ""
+                        fieldValues[CodingPlanFields.BASE_URL] = dataMap["baseUrl"] ?: ""
                         android.util.Log.d("EditCredential", "ChatGPT: apiKey=${if (dataMap["apiKey"]?.isNotBlank() == true) "OK" else "EMPTY"}")
                     }
                     "anthropic", "claude" -> {
-                        fieldValues[2] = dataMap["apiKey"] ?: ""
-                        fieldValues[4] = dataMap["baseUrl"] ?: ""
+                        fieldValues[CodingPlanFields.API_KEY] = dataMap["apiKey"] ?: ""
+                        fieldValues[CodingPlanFields.BASE_URL] = dataMap["baseUrl"] ?: ""
                         android.util.Log.d("EditCredential", "Claude: apiKey=${if (dataMap["apiKey"]?.isNotBlank() == true) "OK" else "EMPTY"}")
                     }
                 }
@@ -283,11 +284,11 @@ private fun EditCredentialForm(
 
     /** Auto-extract cookie from RAW_CURL and fill COOKIE field for CodingPlan */
     fun handleRawCurlChange(value: String) {
-        fieldValues[1] = value
+        fieldValues[CodingPlanFields.RAW_CURL] = value
         if (selectedType == CredentialType.CodingPlan) {
             val extractedCookie = extractCookieFromCurl(value)
             if (!userEditedCookie && extractedCookie.isNotBlank()) {
-                fieldValues[3] = extractedCookie
+                fieldValues[CodingPlanFields.COOKIE] = extractedCookie
             }
         }
     }
@@ -396,8 +397,8 @@ private fun EditCredentialForm(
                         editable = field.editable,
                     )
                 } else {
-                    val isRawCurlField = selectedType == CredentialType.CodingPlan && index == 1
-                    val isCookieField = selectedType == CredentialType.CodingPlan && index == 3
+                    val isRawCurlField = selectedType == CredentialType.CodingPlan && index == CodingPlanFields.RAW_CURL
+                    val isCookieField = selectedType == CredentialType.CodingPlan && index == CodingPlanFields.COOKIE
                     val isMultiline = isRawCurlField || isCookieField
                     BrutalistTextField(
                         value = getField(index),


### PR DESCRIPTION
## Summary
- 新增 `CodingPlanFields.kt` 定义字段索引常量
- 替换所有魔法数字为 `CodingPlanFields.PROVIDER/API_KEY` 等
- 防止一处索引修改导致其他页面静默数据错乱

## Changes
- `domain/model/CodingPlanFields.kt`: 新增常量定义对象
- `AddCredentialScreen.kt`: fieldValues[0/1/2/3/4] → CodingPlanFields 常量
- `EditCredentialScreen.kt`: 同上
- `CredentialCard.kt`: fields.getNotBlank(2/4) → CodingPlanFields.API_KEY/BASE_URL

## Test plan
- [x] Build passes
- [ ] 功能测试：添加/编辑 CodingPlan 凭据
- [ ] 显示测试：CredentialCard 正确显示 API_KEY 和 BASE_URL

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)