### PR TITLE
enhance: CodingPlanQuota 数据模型扩展对标 CodexBar/caut 字段体系

### DIFF
--- a/app/src/main/java/com/lockit/domain/CodingPlanFetcher.kt
+++ b/app/src/main/java/com/lockit/domain/CodingPlanFetcher.kt
@@ -3,26 +3,62 @@ package com.lockit.domain
 import com.lockit.domain.qwen.QwenCodingPlan
 import com.lockit.domain.chatgpt.ChatGPTCodingPlan
 import com.lockit.domain.claude.ClaudeCodingPlan
+import com.lockit.domain.model.ModelQuota
+import java.time.Instant
 
 /**
  * Result of a coding plan quota fetch.
+ * Extended to support multi-model quotas, credits, reset times, and identity.
  */
 data class CodingPlanQuota(
-    val fiveHourUsed: Int = 0,
-    val fiveHourTotal: Int = 0,
+    // === Time window quotas ===
+    val sessionUsed: Int = 0,
+    val sessionTotal: Int = 0,
     val weekUsed: Int = 0,
     val weekTotal: Int = 0,
     val monthUsed: Int = 0,
     val monthTotal: Int = 0,
-    // Instance info
+
+    // === Model-specific quotas (Claude Max / ChatGPT) ===
+    val modelQuotas: Map<String, ModelQuota> = emptyMap(),
+
+    // === Credits / balance ===
+    val creditsRemaining: Double = 0.0,
+    val creditsCurrency: String = "USD",
+
+    // === Extra usage (Claude Max) ===
+    val extraUsageSpent: Double = 0.0,
+    val extraUsageLimit: Double = 0.0,
+
+    // === Instance info ===
     val instanceName: String = "",
     val instanceType: String = "",
     val status: String = "",
     val remainingDays: Int = 0,
+    val planName: String = "",
+    val tier: String = "",
+
+    // === Reset times ===
+    val sessionResetsAt: Instant? = null,
+    val weekResetsAt: Instant? = null,
+    val monthResetsAt: Instant? = null,
+
+    // === Charge info ===
     val chargeAmount: Double = 0.0,
     val chargeType: String = "",
     val autoRenewFlag: Boolean = false,
-)
+
+    // === Identity ===
+    val accountEmail: String = "",
+    val loginMethod: String = "",
+) {
+    // Legacy aliases for backwards compatibility
+    @Deprecated("Use sessionUsed instead", ReplaceWith("sessionUsed"))
+    val fiveHourUsed: Int = sessionUsed
+
+    @Deprecated("Use sessionTotal instead", ReplaceWith("sessionTotal"))
+    val fiveHourTotal: Int = sessionTotal
+}
 
 /**
  * Provider-specific coding plan quota fetcher.

--- a/app/src/main/java/com/lockit/domain/chatgpt/ChatGPTCodingPlan.kt
+++ b/app/src/main/java/com/lockit/domain/chatgpt/ChatGPTCodingPlan.kt
@@ -79,8 +79,8 @@ object ChatGPTCodingPlan : CodingPlanFetcher {
         val weeklyTotal = weeklyLimit?.optInt("total", 0) ?: 0
 
         return CodingPlanQuota(
-            fiveHourUsed = dailyUsed,
-            fiveHourTotal = dailyTotal,
+            sessionUsed = dailyUsed,
+            sessionTotal = dailyTotal,
             weekUsed = weeklyUsed,
             weekTotal = weeklyTotal,
             monthUsed = 0,

--- a/app/src/main/java/com/lockit/domain/claude/ClaudeCodingPlan.kt
+++ b/app/src/main/java/com/lockit/domain/claude/ClaudeCodingPlan.kt
@@ -75,8 +75,8 @@ object ClaudeCodingPlan : CodingPlanFetcher {
         val remaining = usage.optInt("remaining", total - used)
 
         return CodingPlanQuota(
-            fiveHourUsed = used,
-            fiveHourTotal = total,
+            sessionUsed = used,
+            sessionTotal = total,
             weekUsed = 0,
             weekTotal = 0,
             monthUsed = 0,
@@ -85,6 +85,7 @@ object ClaudeCodingPlan : CodingPlanFetcher {
             instanceType = "Claude Pro",
             status = if (remaining > 0) "VALID" else "EXHAUSTED",
             remainingDays = 0,
+            planName = "Claude Pro",
             chargeAmount = 20.0,
             chargeType = "subscription",
             autoRenewFlag = true,

--- a/app/src/main/java/com/lockit/domain/model/ModelQuota.kt
+++ b/app/src/main/java/com/lockit/domain/model/ModelQuota.kt
@@ -1,0 +1,15 @@
+package com.lockit.domain.model
+
+import java.time.Instant
+
+/**
+ * Model-specific quota data.
+ * Used for providers with multiple model quotas (Claude Max, ChatGPT).
+ */
+data class ModelQuota(
+    val modelName: String,            // "Sonnet 4", "Opus 4", "GPT-5.2"
+    val usedPercent: Double = 0.0,
+    val weekUsed: Int = 0,
+    val weekTotal: Int = 0,
+    val resetsAt: Instant? = null,
+)

--- a/app/src/main/java/com/lockit/domain/qwen/QwenCodingPlan.kt
+++ b/app/src/main/java/com/lockit/domain/qwen/QwenCodingPlan.kt
@@ -116,8 +116,8 @@ object QwenCodingPlan : CodingPlanFetcher {
         val quotaInfo = instance.optJSONObject("codingPlanQuotaInfo") ?: return null
 
         return CodingPlanQuota(
-            fiveHourUsed = quotaInfo.optInt("per5HourUsedQuota", 0),
-            fiveHourTotal = quotaInfo.optInt("per5HourTotalQuota", 0),
+            sessionUsed = quotaInfo.optInt("per5HourUsedQuota", 0),
+            sessionTotal = quotaInfo.optInt("per5HourTotalQuota", 0),
             weekUsed = quotaInfo.optInt("perWeekUsedQuota", 0),
             weekTotal = quotaInfo.optInt("perWeekTotalQuota", 0),
             monthUsed = quotaInfo.optInt("perBillMonthUsedQuota", 0),
@@ -126,6 +126,7 @@ object QwenCodingPlan : CodingPlanFetcher {
             instanceType = instance.optString("instanceType", ""),
             status = instance.optString("status", ""),
             remainingDays = instance.optInt("remainingDays", 0),
+            planName = instance.optString("planName", ""),
             chargeAmount = instance.optDouble("chargeAmount", 0.0),
             chargeType = instance.optString("chargeType", ""),
             autoRenewFlag = instance.optBoolean("autoRenewFlag", false),

--- a/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
@@ -1110,7 +1110,7 @@ private fun CodingPlanBoard(
 
             // Quota gauges
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
-                QuotaGauge(stringResource(R.string.quota_5h), quota.fiveHourUsed, quota.fiveHourTotal, Modifier.weight(1f))
+                QuotaGauge(stringResource(R.string.quota_5h), quota.sessionUsed, quota.sessionTotal, Modifier.weight(1f))
                 QuotaGauge(stringResource(R.string.quota_week), quota.weekUsed, quota.weekTotal, Modifier.weight(1f))
                 QuotaGauge(stringResource(R.string.quota_month), quota.monthUsed, quota.monthTotal, Modifier.weight(1f))
             }


### PR DESCRIPTION
## Summary
- 重命名 `fiveHourUsed/Total` → `sessionUsed/Total` (保留 deprecated alias)
- 新增 `ModelQuota` 数据类支持多模型配额 (Claude Max, ChatGPT)
- 新增 credits/余额相关字段
- 新增 reset times (Instant) 支持 ISO-8601 重置时间
- 新增身份字段 (accountEmail, loginMethod)

## Changes
- `domain/model/ModelQuota.kt` (NEW) - 多模型配额数据类
- `domain/CodingPlanFetcher.kt` - 扩展 CodingPlanQuota 字段
- `domain/qwen/QwenCodingPlan.kt` - 使用新字段名 + planName
- `domain/chatgpt/ChatGPTCodingPlan.kt` - daily_limit → sessionUsed/Total
- `domain/claude/ClaudeCodingPlan.kt` - 使用新字段名 + planName
- `ui/screens/repos/ReposScreen.kt` - UI 使用新字段名

## Test plan
- [x] Build passes
- [x] No unit tests exist in this project
- [ ] Manual testing: Coding Plan quota display

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)