### PR TITLE
fix: 添加 toast_credential_error 中文翻译修复 Lint 错误

### DIFF
--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -353,4 +353,5 @@
     <string name="auth_qwen_bailian">百炼千问</string>
     <string name="auth_chatgpt">ChatGPT</string>
     <string name="auth_claude">Claude</string>
+    <string name="toast_credential_error">凭证获取失败</string>
 </resources>


### PR DESCRIPTION
## Summary
- 添加 `toast_credential_error` 中文翻译：凭证获取失败
- 修复 Lint MissingTranslation 错误

## Test plan
- [x] Lint 检查通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)