### PR TITLE
ux: WebView 登录页按钮改为可拖拽悬浮浮动按钮

### DIFF
--- a/app/src/main/java/com/lockit/ui/components/DraggableFloatingButtons.kt
+++ b/app/src/main/java/com/lockit/ui/components/DraggableFloatingButtons.kt
@@ -1,0 +1,145 @@
+package com.lockit.ui.components
+
+import android.os.Build
+import android.view.View
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import com.lockit.R
+import kotlin.math.roundToInt
+
+/**
+ * Draggable floating button container with glassmorphism effect.
+ * Used in WebViewAuthActivity for overlay controls.
+ */
+class DraggableFloatingButtons(
+    private val onBack: () -> Unit,
+    private val onReset: () -> Unit,
+    private val onClose: () -> Unit,
+) {
+
+    fun createView(context: android.content.Context): View {
+        return ComposeView(context).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                FloatingButtonsContent(onBack, onReset, onClose)
+            }
+        }
+    }
+}
+
+@Composable
+private fun FloatingButtonsContent(
+    onBack: () -> Unit,
+    onReset: () -> Unit,
+    onClose: () -> Unit,
+) {
+    val offsetX = remember { mutableStateOf(0f) }
+    val offsetY = remember { mutableStateOf(0f) }
+
+    Box(
+        modifier = Modifier
+            .offset { IntOffset(offsetX.value.roundToInt(), offsetY.value.roundToInt()) }
+            .pointerInput(Unit) {
+                detectDragGestures { change, dragAmount ->
+                    change.consume()
+                    offsetX.value += dragAmount.x
+                    offsetY.value += dragAmount.y
+                }
+            }
+            .glassmorphismBackground()
+            .padding(8.dp)
+    ) {
+        Row {
+            // Back button
+            GlassButton(
+                iconRes = R.drawable.ic_arrow_back,
+                contentDescription = "返回",
+                onClick = onBack
+            )
+
+            // Reset button
+            GlassButton(
+                iconRes = R.drawable.ic_refresh,
+                contentDescription = "重新登录",
+                onClick = onReset
+            )
+
+            // Close button
+            GlassButton(
+                iconRes = R.drawable.ic_close,
+                contentDescription = "关闭",
+                onClick = onClose,
+                isDestructive = true
+            )
+        }
+    }
+}
+
+@Composable
+private fun GlassButton(
+    iconRes: Int,
+    contentDescription: String,
+    onClick: () -> Unit,
+    isDestructive: Boolean = false,
+) {
+    val iconColor = if (isDestructive) Color(0xFFA30000) else Color.White
+
+    IconButton(
+        onClick = onClick,
+        modifier = Modifier
+            .size(40.dp)
+            .background(
+                color = if (isDestructive) Color(0x40A30000) else Color(0x30FFFFFF),
+                shape = CircleShape
+            )
+    ) {
+        Icon(
+            painter = painterResource(id = iconRes),
+            contentDescription = contentDescription,
+            tint = iconColor,
+            modifier = Modifier.size(20.dp)
+        )
+    }
+}
+
+@Composable
+private fun Modifier.glassmorphismBackground(): Modifier {
+    // Semi-transparent glass effect with shadow
+    // API 31+ would add RenderEffect blur, but for compatibility we use simple transparency
+    return this
+        .shadow(8.dp, RoundedCornerShape(24.dp))
+        .background(
+            color = Color(0x60FFFFFF), // Semi-transparent white
+            shape = RoundedCornerShape(24.dp)
+        )
+        .border(
+            width = 1.dp,
+            color = Color(0x40FFFFFF), // Border glow
+            shape = RoundedCornerShape(24.dp)
+        )
+}
+
+// Removed custom offset extension - using standard Modifier.offset(IntOffset)

--- a/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
+++ b/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
@@ -17,6 +17,7 @@ import androidx.core.view.WindowInsetsCompat
 import com.lockit.domain.qwen.BailianAuthClient
 import com.lockit.domain.chatgpt.ChatGptAuthClient
 import com.lockit.domain.claude.ClaudeAuthClient
+import com.lockit.ui.components.DraggableFloatingButtons
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -85,30 +86,10 @@ class WebViewAuthActivity : Activity() {
             loadUrl(loginUrl)
         }
 
-        val backButton = android.widget.Button(this).apply {
-            text = "返回"
-            setBackgroundColor(android.graphics.Color.parseColor("#333333"))
-            setTextColor(android.graphics.Color.WHITE)
-            setOnClickListener {
-                webView?.goBack()
-            }
-        }
-
-        val closeButton = android.widget.Button(this).apply {
-            text = "关闭"
-            setBackgroundColor(android.graphics.Color.parseColor("#A30000"))
-            setTextColor(android.graphics.Color.WHITE)
-            setOnClickListener {
-                setResult(RESULT_CANCELED)
-                finish()
-            }
-        }
-
-        val resetButton = android.widget.Button(this).apply {
-            text = "重新登录"
-            setBackgroundColor(android.graphics.Color.parseColor("#666666"))
-            setTextColor(android.graphics.Color.WHITE)
-            setOnClickListener {
+        // Glassmorphism floating buttons - draggable overlay
+        val floatingButtons = DraggableFloatingButtons(
+            onBack = { webView?.goBack() },
+            onReset = {
                 CookieManager.getInstance().removeAllCookies(null)
                 CookieManager.getInstance().flush()
                 webView?.clearCache(true)
@@ -123,30 +104,20 @@ class WebViewAuthActivity : Activity() {
                 }
                 webView?.loadUrl(loginUrl)
                 android.widget.Toast.makeText(this@WebViewAuthActivity, "已清除登录数据", android.widget.Toast.LENGTH_SHORT).show()
+            },
+            onClose = {
+                setResult(RESULT_CANCELED)
+                finish()
             }
-        }
-
-        // Button container - vertical layout on right side center
-        val buttonContainer = android.widget.LinearLayout(this).apply {
-            orientation = android.widget.LinearLayout.VERTICAL
-            setPadding(8, 8, 8, 8)
-        }
-        buttonContainer.addView(backButton, android.widget.LinearLayout.LayoutParams(
-            android.widget.LinearLayout.LayoutParams.WRAP_CONTENT,
-            android.widget.LinearLayout.LayoutParams.WRAP_CONTENT
-        ).apply { setMargins(0, 0, 0, 8) })
-        buttonContainer.addView(resetButton, android.widget.LinearLayout.LayoutParams(
-            android.widget.LinearLayout.LayoutParams.WRAP_CONTENT,
-            android.widget.LinearLayout.LayoutParams.WRAP_CONTENT
-        ).apply { setMargins(0, 0, 0, 8) })
-        buttonContainer.addView(closeButton)
+        ).createView(this)
 
         val buttonLayout = FrameLayout.LayoutParams(
             FrameLayout.LayoutParams.WRAP_CONTENT,
             FrameLayout.LayoutParams.WRAP_CONTENT
         ).apply {
-            gravity = android.view.Gravity.RIGHT or android.view.Gravity.CENTER_VERTICAL
-            setMargins(0, 0, 16, 0)
+            // Default position: top-right with safe margin
+            gravity = android.view.Gravity.TOP or android.view.Gravity.RIGHT
+            setMargins(16, 80, 16, 0)
         }
 
         val webViewLayout = FrameLayout.LayoutParams(
@@ -155,7 +126,7 @@ class WebViewAuthActivity : Activity() {
         )
 
         rootView.addView(webView, webViewLayout)
-        rootView.addView(buttonContainer, buttonLayout)
+        rootView.addView(floatingButtons, buttonLayout)
 
         // Apply window insets - WebView needs to avoid status bar and navigation bar
         ViewCompat.setOnApplyWindowInsetsListener(rootView) { view, insets ->

--- a/app/src/main/res/drawable/ic_arrow_back.xml
+++ b/app/src/main/res/drawable/ic_arrow_back.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_close.xml
+++ b/app/src/main/res/drawable/ic_close.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_refresh.xml
+++ b/app/src/main/res/drawable/ic_refresh.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M17.65,6.35C16.2,4.9 14.21,4 12,4c-4.42,0 -7.99,3.58 -7.99,8s3.57,8 7.99,8c3.73,0 6.84,-2.55 7.73,-6h-2.08c-0.78,2.39 -2.97,4 -5.65,4 -3.31,0 -6,-2.69 -6,-6s2.69,-6 6,-6c1.66,0 3.14,0.69 4.22,1.78L13,11h7V4l-2.35,2.35z"/>
+</vector>


### PR DESCRIPTION
## Summary
- 替换丑陋的原生方块按钮为 Compose 悬浮按钮
- 新增 DraggableFloatingButtons 组件（毛玻璃效果）
- 支持手指拖拽移动位置
- 默认位置：屏幕右上角
- 三个圆形按钮：返回 ← / 重登 🔄 / 关闭 ✕
- 关闭按钮使用红色突出显示

## Changes
- `ui/components/DraggableFloatingButtons.kt` (NEW) - 可拖拽悬浮按钮组件
- `ui/screens/auth/WebViewAuthActivity.kt` - 使用新组件替换原按钮
- `res/drawable/ic_arrow_back.xml` (NEW) - 返回图标
- `res/drawable/ic_refresh.xml` (NEW) - 重登图标  
- `res/drawable/ic_close.xml` (NEW) - 关闭图标

## Test plan
- [x] Build passes
- [x] Lint passes
- [ ] Manual testing: WebView 登录页按钮拖拽功能

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)