### PR TITLE
feat: CodingPlan 凭据刷新功能 + 凭据有效性检查器

### DIFF
--- a/app/src/main/java/com/lockit/domain/CredentialValidityChecker.kt
+++ b/app/src/main/java/com/lockit/domain/CredentialValidityChecker.kt
@@ -1,0 +1,61 @@
+package com.lockit.domain
+
+import com.lockit.domain.model.Credential
+import com.lockit.domain.model.CredentialType
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Utility to check if a credential's authentication data is still valid.
+ * Used for displaying expiry status in UI.
+ */
+object CredentialValidityChecker {
+
+    /**
+     * Check if a CodingPlan credential's auth data is still valid.
+     * Attempts to fetch quota - if successful, credential is valid.
+     *
+     * @param credential The credential to check
+     * @return true if valid, false if expired/invalid
+     */
+    suspend fun isCredentialValid(credential: Credential): Boolean = withContext(Dispatchers.IO) {
+        if (credential.type != CredentialType.CodingPlan) true // Non-CodingPlan credentials don't expire
+        else {
+            val provider = credential.metadata["provider"]
+            if (provider == null) false
+            else {
+                val fetcher = CodingPlanFetchers.forProvider(provider)
+                if (fetcher == null) false
+                else {
+                    try {
+                        val quota = fetcher.fetchQuota(credential.metadata)
+                        quota != null && quota.status.isNotBlank()
+                    } catch (e: Exception) {
+                        android.util.Log.e("CredentialValidity", "Check failed for ${credential.name}: ${e.message}")
+                        false
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Batch check multiple credentials.
+     * Returns a map of credential ID to validity status.
+     */
+    suspend fun checkCredentials(credentials: List<Credential>): Map<String, Boolean> = withContext(Dispatchers.IO) {
+        val codingPlanCreds = credentials.filter { it.type == CredentialType.CodingPlan }
+        val results = mutableMapOf<String, Boolean>()
+
+        for (cred in codingPlanCreds) {
+            results[cred.id] = isCredentialValid(cred)
+        }
+
+        // Non-CodingPlan credentials are always "valid" (no expiry)
+        credentials.filter { it.type != CredentialType.CodingPlan }.forEach {
+            results[it.id] = true
+        }
+
+        results
+    }
+}

--- a/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
+++ b/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
@@ -1,5 +1,6 @@
 package com.lockit.ui.screens.auth
 
+import androidx.activity.ComponentActivity
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
@@ -39,7 +40,7 @@ import java.net.URL
  * 4. Activity detects login success and extracts tokens/cookies
  * 5. Returns extracted credentials via Intent result (JSON serialized)
  */
-class WebViewAuthActivity : Activity() {
+class WebViewAuthActivity : ComponentActivity() {
 
     companion object {
         const val EXTRA_PROVIDER = "provider"

--- a/app/src/main/java/com/lockit/ui/screens/secret_details/SecretDetailsScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/secret_details/SecretDetailsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.filled.Block
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Fingerprint
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.HorizontalDivider
@@ -59,6 +60,7 @@ import com.lockit.ui.components.extractSecretValue
 import com.lockit.ui.components.findActivity
 import com.lockit.ui.components.formatTime
 import com.lockit.ui.components.parseCredentialFields
+import com.lockit.ui.screens.auth.WebViewAuthActivity
 import com.lockit.ui.theme.IndustrialOrange
 import com.lockit.ui.theme.JetBrainsMonoFamily
 import com.lockit.ui.theme.Primary
@@ -68,6 +70,7 @@ import com.lockit.ui.theme.TacticalRed
 import com.lockit.ui.theme.White
 import com.lockit.utils.BiometricUtils
 import kotlinx.coroutines.launch
+import org.json.JSONObject
 import java.time.Instant
 
 @Composable
@@ -89,7 +92,41 @@ fun SecretDetailsScreen(
     val scope = rememberCoroutineScope()
     val clipboardManager = LocalClipboardManager.current
     val view = LocalView.current
+    val context = androidx.compose.ui.platform.LocalContext.current
     fun getActivity() = view.findActivity()
+
+    // WebView auth launcher for refreshing CodingPlan credentials
+    val webViewAuthLauncher = androidx.activity.compose.rememberLauncherForActivityResult(
+        contract = androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode == WebViewAuthActivity.RESULT_SUCCESS) {
+            val credentialData = result.data?.getStringExtra(WebViewAuthActivity.EXTRA_CREDENTIAL_DATA)
+            if (credentialData != null && credential != null) {
+                val json = JSONObject(credentialData)
+                val newMetadata = mutableMapOf<String, String>()
+                json.keys().forEach { key ->
+                    newMetadata[key] = json.optString(key, "")
+                }
+                // Update credential with new auth data
+                scope.launch {
+                    app.vaultManager.updateCredential(
+                        id = credential!!.id,
+                        name = credential!!.name,
+                        type = credential!!.type,
+                        service = credential!!.service,
+                        key = credential!!.key,
+                        value = credential!!.value,
+                        metadata = newMetadata.toString(),
+                    )
+                    // Reload credential
+                    credential = app.vaultManager.getCredentialById(credentialId)
+                    toastMessage = "AUTH_REFRESHED: ${credential!!.name}"
+                }
+            }
+        } else if (result.resultCode == WebViewAuthActivity.RESULT_FAILED) {
+            toastMessage = "AUTH_REFRESH_FAILED"
+        }
+    }
 
     LaunchedEffect(credentialId) {
         isLoading = true
@@ -249,6 +286,15 @@ fun SecretDetailsScreen(
                     onHideEmailPassword = if (cred.type == CredentialType.Email) {
                         { revealedEmailPassword = null }
                     } else null,
+                    onRefreshAuth = if (cred.type == CredentialType.CodingPlan) {
+                        {
+                            val provider = try {
+                                org.json.JSONObject(cred.metadata).optString("provider", "qwen_bailian")
+                            } catch (e: Exception) { "qwen_bailian" }
+                            val intent = WebViewAuthActivity.createIntent(context, provider)
+                            webViewAuthLauncher.launch(intent)
+                        }
+                    } else null,
                 )
                 Spacer(modifier = Modifier.height(16.dp))
             }
@@ -315,6 +361,7 @@ private fun SecretValueSection(
     onEmailPasswordReveal: (() -> Unit)? = null,
     revealedEmailPassword: String? = null,
     onHideEmailPassword: (() -> Unit)? = null,
+    onRefreshAuth: (() -> Unit)? = null,
 ) {
     BrutalistCard {
         Column(modifier = Modifier.padding(16.dp)) {
@@ -336,6 +383,105 @@ private fun SecretValueSection(
 
             // Show structured data based on credential type
             when (credential.type) {
+                CredentialType.CodingPlan -> {
+                    val metadata = parseCredentialFields(credential.value)
+                    val provider = metadata.getOrNull(0) ?: credential.metadata.let { meta ->
+                        try {
+                            org.json.JSONObject(meta).optString("provider", "")
+                        } catch (e: Exception) { "" }
+                    }.takeIf { it.isNotBlank() } ?: "qwen_bailian"
+
+                    // Provider info
+                    Box(
+                        modifier = Modifier.fillMaxWidth()
+                            .background(SurfaceLow).border(1.dp, Primary).padding(12.dp),
+                    ) {
+                        Column {
+                            Text(
+                                text = "PROVIDER",
+                                fontFamily = JetBrainsMonoFamily,
+                                fontWeight = FontWeight.Bold,
+                                fontSize = 9.sp,
+                                letterSpacing = 1.sp,
+                                color = IndustrialOrange,
+                            )
+                            Spacer(modifier = Modifier.height(4.dp))
+                            Text(
+                                text = provider.uppercase(),
+                                fontFamily = JetBrainsMonoFamily,
+                                fontSize = 14.sp,
+                                color = Primary,
+                                fontWeight = FontWeight.Bold,
+                            )
+                        }
+                    }
+
+                    // API Key (if available)
+                    val apiKey = metadata.getOrNull(2)?.takeIf { it.isNotBlank() }
+                        ?: credential.metadata.let { meta ->
+                            try { org.json.JSONObject(meta).optString("apiKey", "") } catch (e: Exception) { "" }
+                        }.takeIf { it.isNotBlank() }
+
+                    if (apiKey != null) {
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Box(
+                            modifier = Modifier.fillMaxWidth()
+                                .background(SurfaceLow).border(1.dp, Primary).padding(12.dp),
+                        ) {
+                            Column {
+                                Text(
+                                    text = "API_KEY",
+                                    fontFamily = JetBrainsMonoFamily,
+                                    fontWeight = FontWeight.Bold,
+                                    fontSize = 9.sp,
+                                    letterSpacing = 1.sp,
+                                    color = IndustrialOrange,
+                                )
+                                Spacer(modifier = Modifier.height(4.dp))
+                                Text(
+                                    text = if (isRevealed) apiKey else "•".repeat(20),
+                                    fontFamily = JetBrainsMonoFamily,
+                                    fontSize = 12.sp,
+                                    color = if (isRevealed) Primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                                    maxLines = if (isRevealed) 3 else 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            }
+                        }
+                    }
+
+                    // Base URL (if available)
+                    val baseUrl = metadata.getOrNull(4)?.takeIf { it.isNotBlank() }
+                        ?: credential.metadata.let { meta ->
+                            try { org.json.JSONObject(meta).optString("baseUrl", "") } catch (e: Exception) { "" }
+                        }.takeIf { it.isNotBlank() }
+
+                    if (baseUrl != null) {
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Box(
+                            modifier = Modifier.fillMaxWidth()
+                                .background(SurfaceLow).border(1.dp, Primary).padding(12.dp),
+                        ) {
+                            Column {
+                                Text(
+                                    text = "BASE_URL",
+                                    fontFamily = JetBrainsMonoFamily,
+                                    fontWeight = FontWeight.Bold,
+                                    fontSize = 9.sp,
+                                    letterSpacing = 1.sp,
+                                    color = IndustrialOrange,
+                                )
+                                Spacer(modifier = Modifier.height(4.dp))
+                                Text(
+                                    text = baseUrl,
+                                    fontFamily = JetBrainsMonoFamily,
+                                    fontSize = 11.sp,
+                                    color = Primary,
+                                )
+                            }
+                        }
+                    }
+                }
                 CredentialType.Phone -> {
                     val phoneFields = parseCredentialFields(credential.value)
                     val phoneNumber = phoneFields.getOrNull(1)?.takeIf { it.isNotBlank() }
@@ -565,7 +711,8 @@ private fun SecretValueSection(
 
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 if (credential.type != CredentialType.Email && credential.type != CredentialType.Phone
-                    && credential.type != CredentialType.IdCard && credential.type != CredentialType.Note) {
+                    && credential.type != CredentialType.IdCard && credential.type != CredentialType.Note
+                    && credential.type != CredentialType.CodingPlan) {
                     BrutalistButton(
                         text = if (isRevealed) "HIDE" else "REVEAL",
                         onClick = onReveal,
@@ -573,6 +720,17 @@ private fun SecretValueSection(
                         modifier = Modifier.weight(1f),
                         useMonoFont = true,
                         icon = Icons.Default.Visibility,
+                        iconPosition = IconPosition.Start,
+                    )
+                }
+                if (credential.type == CredentialType.CodingPlan && onRefreshAuth != null) {
+                    BrutalistButton(
+                        text = "REFRESH_AUTH",
+                        onClick = onRefreshAuth,
+                        variant = ButtonVariant.Primary,
+                        modifier = Modifier.weight(1f),
+                        useMonoFont = true,
+                        icon = Icons.Default.Refresh,
                         iconPosition = IconPosition.Start,
                     )
                 }

--- a/app/src/main/java/com/lockit/ui/screens/secret_details/SecretDetailsScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/secret_details/SecretDetailsScreen.kt
@@ -109,18 +109,28 @@ fun SecretDetailsScreen(
                 }
                 // Update credential with new auth data
                 scope.launch {
-                    app.vaultManager.updateCredential(
-                        id = credential!!.id,
-                        name = credential!!.name,
-                        type = credential!!.type,
-                        service = credential!!.service,
-                        key = credential!!.key,
-                        value = credential!!.value,
-                        metadata = newMetadata.toString(),
-                    )
-                    // Reload credential
-                    credential = app.vaultManager.getCredentialById(credentialId)
-                    toastMessage = "AUTH_REFRESHED: ${credential!!.name}"
+                    val currentCred = credential
+                    if (currentCred != null) {
+                        // Serialize metadata as proper JSON (not Map.toString())
+                        val metadataJson = JSONObject(newMetadata as Map<*, *>).toString()
+                        // Reconstruct value string to keep UI in sync with metadata
+                        val provider = newMetadata["provider"] ?: ""
+                        val apiKey = newMetadata["apiKey"] ?: ""
+                        val baseUrl = newMetadata["baseUrl"] ?: ""
+                        val newValue = "$provider // $apiKey // ${currentCred.key} // $baseUrl"
+                        app.vaultManager.updateCredential(
+                            id = currentCred.id,
+                            name = currentCred.name,
+                            type = currentCred.type,
+                            service = currentCred.service,
+                            key = currentCred.key,
+                            value = newValue,
+                            metadata = metadataJson,
+                        )
+                        // Reload credential
+                        credential = app.vaultManager.getCredentialById(credentialId)
+                        toastMessage = "AUTH_REFRESHED: ${credential?.name ?: "UNKNOWN"}"
+                    }
                 }
             }
         } else if (result.resultCode == WebViewAuthActivity.RESULT_FAILED) {


### PR DESCRIPTION
## Summary
- 新增 CredentialValidityChecker 检查 CodingPlan 凭据有效性（通过 API 调用测试）
- SecretDetailsScreen 添加 CodingPlan 专属展示区域 (provider/apiKey/baseUrl)
- 添加 REFRESH_AUTH 按钮，支持 WebView 一键刷新 CodingPlan 凭据
- webViewAuthLauncher 支持百炼/ChatGPT/Claude 三种 provider

## Changes
- `CredentialValidityChecker.kt` (新增) - 凭据有效性检查器
- `SecretDetailsScreen.kt` - CodingPlan 展示 + 刷新按钮 + webViewAuthLauncher

## Test plan
- [x] Build passes (`./gradlew assembleDebug`)
- [x] Lint passes (`./gradlew lintDebug`)
- [ ] 手动测试：创建 CodingPlan 凭据，点击 REFRESH_AUTH 按钮
- [ ] 验证 WebView 打开正确 provider 登录页
- [ ] 验证刷新后凭据更新成功

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)