### PR TITLE
ux: WebView 悬浮按钮改为深色背景，支持全屏拖动

### DIFF
--- a/app/src/main/java/com/lockit/data/audit/AuditLogger.kt
+++ b/app/src/main/java/com/lockit/data/audit/AuditLogger.kt
@@ -22,6 +22,7 @@ enum class AuditSeverity { Info, Warning, Danger }
  * Simple audit log stored in SharedPreferences.
  * Logs are kept for display up to 30 days, export up to 1 year.
  * Uses JSON format for reliable parsing (no delimiter collision issues).
+ * Thread-safe: uses synchronized lock for read-modify-write operations.
  */
 class AuditLogger(context: Context) {
 
@@ -34,23 +35,29 @@ class AuditLogger(context: Context) {
 
     private val keyEntries = "audit_entries"
 
+    // Lock for thread-safe read-modify-write operations
+    private val lock = Any()
+
     /**
      * Record a new audit event.
+     * Thread-safe: uses synchronized block to prevent data loss under concurrent access.
      */
     fun log(
         action: String,
         detail: String = "",
         severity: AuditSeverity = AuditSeverity.Info,
     ) {
-        val entry = AuditEntry(
-            action = action,
-            detail = detail,
-            timestamp = Instant.now().toEpochMilli(),
-            severity = severity,
-        )
-        val current = getAllEntries()
-        val updated = listOf(entry) + current
-        saveEntries(updated)
+        synchronized(lock) {
+            val entry = AuditEntry(
+                action = action,
+                detail = detail,
+                timestamp = Instant.now().toEpochMilli(),
+                severity = severity,
+            )
+            val current = getAllEntriesInternal()
+            val updated = listOf(entry) + current
+            saveEntriesInternal(updated)
+        }
     }
 
     /**
@@ -86,21 +93,36 @@ class AuditLogger(context: Context) {
 
     /**
      * Clean up entries older than 1 year.
+     * Thread-safe: uses synchronized block.
      */
     fun pruneOldEntries(maxDays: Int = 365) {
-        val cutoff = Instant.now().minusSeconds(maxDays.toLong() * 24 * 3600)
-        val kept = getAllEntries().filter { Instant.ofEpochMilli(it.timestamp).isAfter(cutoff) }
-        saveEntries(kept)
+        synchronized(lock) {
+            val cutoff = Instant.now().minusSeconds(maxDays.toLong() * 24 * 3600)
+            val kept = getAllEntriesInternal().filter { Instant.ofEpochMilli(it.timestamp).isAfter(cutoff) }
+            saveEntriesInternal(kept)
+        }
     }
 
     // --- Private ---
 
     private fun getAllEntries(): List<AuditEntry> {
+        synchronized(lock) {
+            return getAllEntriesInternal()
+        }
+    }
+
+    private fun getAllEntriesInternal(): List<AuditEntry> {
         val json = prefs.getString(keyEntries, null) ?: return emptyList()
         return parseJson(json)
     }
 
     private fun saveEntries(entries: List<AuditEntry>) {
+        synchronized(lock) {
+            saveEntriesInternal(entries)
+        }
+    }
+
+    private fun saveEntriesInternal(entries: List<AuditEntry>) {
         prefs.edit { putString(keyEntries, toJson(entries)) }
     }
 

--- a/app/src/main/java/com/lockit/data/vault/VaultManager.kt
+++ b/app/src/main/java/com/lockit/data/vault/VaultManager.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import com.lockit.utils.SearchMatcher
 import java.time.Instant
 
@@ -144,11 +145,15 @@ class VaultManager(
     }
 
     suspend fun getCredentialById(id: String): Credential? {
-        val masterKey = requireMasterKey()
-        val entity = dao.getById(id) ?: return null
-        val credential = decryptCredential(entity, masterKey)
-        auditLogger.log("CREDENTIAL_VIEWED", "${credential.name} - details accessed", AuditSeverity.Info)
-        return credential
+        return withContext(Dispatchers.IO) {
+            val masterKey = requireMasterKey()
+            val entity = dao.getById(id)
+            if (entity == null) null else {
+                val credential = decryptCredential(entity, masterKey)
+                auditLogger.log("CREDENTIAL_VIEWED", "${credential.name} - details accessed", AuditSeverity.Info)
+                credential
+            }
+        }
     }
 
     fun searchCredentials(query: String): Flow<List<Credential>> {

--- a/app/src/main/java/com/lockit/ui/components/DraggableFloatingButtons.kt
+++ b/app/src/main/java/com/lockit/ui/components/DraggableFloatingButtons.kt
@@ -24,14 +24,18 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.lockit.R
+import com.lockit.ui.theme.Primary
+import com.lockit.ui.theme.IndustrialOrange
+import com.lockit.ui.theme.TacticalRed
 import kotlin.math.roundToInt
 
 /**
- * Draggable floating button container with glassmorphism effect.
+ * Draggable floating button container with visible styling.
  * Used in WebViewAuthActivity for overlay controls.
  */
 class DraggableFloatingButtons(
@@ -59,62 +63,82 @@ private fun FloatingButtonsContent(
     val offsetX = remember { mutableStateOf(0f) }
     val offsetY = remember { mutableStateOf(0f) }
 
+    // Get screen bounds for clamping
+    val density = LocalDensity.current
+    val screenWidthPx = with(density) {
+        androidx.compose.ui.platform.LocalConfiguration.current.screenWidthDp.dp.toPx()
+    }
+    val screenHeightPx = with(density) {
+        androidx.compose.ui.platform.LocalConfiguration.current.screenHeightDp.dp.toPx()
+    }
+    val buttonWidthPx = with(density) { 140.dp.toPx() } // Approximate button container width
+    val buttonHeightPx = with(density) { 56.dp.toPx() } // Approximate button container height
+
     Box(
         modifier = Modifier
             .offset { IntOffset(offsetX.value.roundToInt(), offsetY.value.roundToInt()) }
             .pointerInput(Unit) {
                 detectDragGestures { change, dragAmount ->
                     change.consume()
-                    offsetX.value += dragAmount.x
-                    offsetY.value += dragAmount.y
+                    // Update position and clamp to screen bounds
+                    val newX = offsetX.value + dragAmount.x
+                    val newY = offsetY.value + dragAmount.y
+                    // Clamp to keep buttons visible on screen
+                    offsetX.value = newX.coerceIn(-screenWidthPx + buttonWidthPx / 2, screenWidthPx - buttonWidthPx)
+                    offsetY.value = newY.coerceIn(-100f, screenHeightPx - buttonHeightPx - 100f)
                 }
             }
-            .glassmorphismBackground()
+            .visibleBackground()
             .padding(8.dp)
     ) {
         Row {
             // Back button
-            GlassButton(
+            VisibleButton(
                 iconRes = R.drawable.ic_arrow_back,
                 contentDescription = "返回",
-                onClick = onBack
+                onClick = onBack,
+                backgroundColor = Color(0x80111111),
+                iconColor = Color.White
             )
 
             // Reset button
-            GlassButton(
+            VisibleButton(
                 iconRes = R.drawable.ic_refresh,
                 contentDescription = "重新登录",
-                onClick = onReset
+                onClick = onReset,
+                backgroundColor = Color(0x80B34700),
+                iconColor = Color.White
             )
 
             // Close button
-            GlassButton(
+            VisibleButton(
                 iconRes = R.drawable.ic_close,
                 contentDescription = "关闭",
                 onClick = onClose,
-                isDestructive = true
+                backgroundColor = Color(0x80A30000),
+                iconColor = Color.White
             )
         }
     }
 }
 
 @Composable
-private fun GlassButton(
+private fun VisibleButton(
     iconRes: Int,
     contentDescription: String,
     onClick: () -> Unit,
-    isDestructive: Boolean = false,
+    backgroundColor: Color,
+    iconColor: Color,
 ) {
-    val iconColor = if (isDestructive) Color(0xFFA30000) else Color.White
-
     IconButton(
         onClick = onClick,
         modifier = Modifier
             .size(40.dp)
             .background(
-                color = if (isDestructive) Color(0x40A30000) else Color(0x30FFFFFF),
+                color = backgroundColor,
                 shape = CircleShape
             )
+            .border(1.dp, Color.White.copy(alpha = 0.3f), CircleShape)
     ) {
         Icon(
             painter = painterResource(id = iconRes),
@@ -126,20 +150,17 @@ private fun GlassButton(
 }
 
 @Composable
-private fun Modifier.glassmorphismBackground(): Modifier {
-    // Semi-transparent glass effect with shadow
-    // API 31+ would add RenderEffect blur, but for compatibility we use simple transparency
+private fun Modifier.visibleBackground(): Modifier {
+    // Dark background with white border - visible on any page color
     return this
         .shadow(8.dp, RoundedCornerShape(24.dp))
         .background(
-            color = Color(0x60FFFFFF), // Semi-transparent white
+            color = Color(0x90111111), // Dark semi-transparent (visible on white)
             shape = RoundedCornerShape(24.dp)
         )
         .border(
-            width = 1.dp,
-            color = Color(0x40FFFFFF), // Border glow
+            width = 1.5.dp,
+            color = Color.White.copy(alpha = 0.5f), // White border for contrast
             shape = RoundedCornerShape(24.dp)
         )
 }
-
-// Removed custom offset extension - using standard Modifier.offset(IntOffset)

--- a/app/src/main/java/com/lockit/ui/components/DraggableFloatingButtons.kt
+++ b/app/src/main/java/com/lockit/ui/components/DraggableFloatingButtons.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -16,12 +15,12 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
@@ -30,9 +29,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.lockit.R
-import com.lockit.ui.theme.Primary
-import com.lockit.ui.theme.IndustrialOrange
-import com.lockit.ui.theme.TacticalRed
 import kotlin.math.roundToInt
 
 /**
@@ -61,82 +57,84 @@ private fun FloatingButtonsContent(
     onReset: () -> Unit,
     onClose: () -> Unit,
 ) {
-    // Get screen bounds for clamping
+    // Get screen bounds for clamping (recalculated on config change)
     val density = LocalDensity.current
-    val screenWidthPx = with(density) {
-        androidx.compose.ui.platform.LocalConfiguration.current.screenWidthDp.dp.toPx()
-    }
-    val screenHeightPx = with(density) {
-        androidx.compose.ui.platform.LocalConfiguration.current.screenHeightDp.dp.toPx()
-    }
-    val buttonWidthPx = with(density) { 180.dp.toPx() } // Increased for 4 buttons
+    val configuration = androidx.compose.ui.platform.LocalConfiguration.current
+    val screenWidthPx = with(density) { configuration.screenWidthDp.dp.toPx() }
+    val screenHeightPx = with(density) { configuration.screenHeightDp.dp.toPx() }
+    val buttonWidthPx = with(density) { 180.dp.toPx() }
     val buttonHeightPx = with(density) { 56.dp.toPx() }
 
     // Left/right side toggle state
     val isOnRight = remember { mutableStateOf(true) }
 
-    // Position: initially right-middle
-    val offsetX = remember { mutableStateOf(screenWidthPx - buttonWidthPx - 16f) }
-    val offsetY = remember { mutableStateOf(screenHeightPx / 2 - buttonHeightPx / 2) }
+    // Position: relative offset from gravity anchor (TOP|RIGHT)
+    // offsetX: 0 = right edge, negative = moves left
+    // offsetY: 0 = top margin (100dp), positive = moves down
+    val offsetX = remember { mutableStateOf(0f) }
+    val offsetY = remember { mutableStateOf(screenHeightPx / 2 - 100f - buttonHeightPx / 2) }
+
+    // Recalculate Y position on screen rotation
+    LaunchedEffect(configuration.screenHeightDp) {
+        if (offsetY.value > screenHeightPx - buttonHeightPx - 100f) {
+            offsetY.value = screenHeightPx - buttonHeightPx - 100f
+        }
+    }
 
     // Snap to side function
     fun snapToSide(right: Boolean) {
         isOnRight.value = right
-        offsetX.value = if (right) screenWidthPx - buttonWidthPx - 16f else 16f
+        // offsetX: 0 = right, -(screenWidth - buttonWidth) = left
+        offsetX.value = if (right) 0f else -(screenWidthPx - buttonWidthPx - 32f)
     }
 
-    // Full-screen transparent container for touch capture
+    // Button container - positioned relative to gravity anchor
     Box(
-        modifier = Modifier.fillMaxSize()
-    ) {
-        // Positioned button container (draggable anywhere)
-        Box(
-            modifier = Modifier
-                .offset { IntOffset(offsetX.value.roundToInt(), offsetY.value.roundToInt()) }
-                .pointerInput(Unit) {
-                    detectDragGestures { change, dragAmount ->
-                        change.consume()
-                        val newX = offsetX.value + dragAmount.x
-                        val newY = offsetY.value + dragAmount.y
-                        // Clamp to keep buttons visible
-                        offsetX.value = newX.coerceIn(0f, screenWidthPx - buttonWidthPx)
-                        offsetY.value = newY.coerceIn(0f, screenHeightPx - buttonHeightPx)
-                    }
+        modifier = Modifier
+            .offset { IntOffset(offsetX.value.roundToInt(), offsetY.value.roundToInt()) }
+            .pointerInput(Unit) {
+                detectDragGestures { change, dragAmount ->
+                    change.consume()
+                    val newX = offsetX.value + dragAmount.x
+                    val newY = offsetY.value + dragAmount.y
+                    // Clamp: can move from right (0) to left (-screenWidth+buttonWidth+32)
+                    // Y: 0 to screenHeight - buttonHeight - 100
+                    offsetX.value = newX.coerceIn(-(screenWidthPx - buttonWidthPx - 32f), 0f)
+                    offsetY.value = newY.coerceIn(0f, screenHeightPx - buttonHeightPx - 100f)
                 }
-                .visibleBackground()
-                .padding(8.dp)
-        ) {
-            Row {
-                // Toggle position button (left/right snap)
-                VisibleButton(
-                    iconRes = R.drawable.ic_swap_horiz,
-                    contentDescription = "切换位置",
-                    onClick = { snapToSide(!isOnRight.value) },
-                    backgroundColor = Color(0x80B34700),
-                    iconColor = Color.White
-                )
-                VisibleButton(
-                    iconRes = R.drawable.ic_arrow_back,
-                    contentDescription = "返回",
-                    onClick = onBack,
-                    backgroundColor = Color(0x80111111),
-                    iconColor = Color.White
-                )
-                VisibleButton(
-                    iconRes = R.drawable.ic_refresh,
-                    contentDescription = "重新登录",
-                    onClick = onReset,
-                    backgroundColor = Color(0x80B34700),
-                    iconColor = Color.White
-                )
-                VisibleButton(
-                    iconRes = R.drawable.ic_close,
-                    contentDescription = "关闭",
-                    onClick = onClose,
-                    backgroundColor = Color(0x80A30000),
-                    iconColor = Color.White
-                )
             }
+            .visibleBackground()
+            .padding(8.dp)
+    ) {
+        Row {
+            VisibleButton(
+                iconRes = R.drawable.ic_swap_horiz,
+                contentDescription = "切换位置",
+                onClick = { snapToSide(!isOnRight.value) },
+                backgroundColor = Color(0x80B34700),
+                iconColor = Color.White
+            )
+            VisibleButton(
+                iconRes = R.drawable.ic_arrow_back,
+                contentDescription = "返回",
+                onClick = onBack,
+                backgroundColor = Color(0x80111111),
+                iconColor = Color.White
+            )
+            VisibleButton(
+                iconRes = R.drawable.ic_refresh,
+                contentDescription = "重新登录",
+                onClick = onReset,
+                backgroundColor = Color(0x80B34700),
+                iconColor = Color.White
+            )
+            VisibleButton(
+                iconRes = R.drawable.ic_close,
+                contentDescription = "关闭",
+                onClick = onClose,
+                backgroundColor = Color(0x80A30000),
+                iconColor = Color.White
+            )
         }
     }
 }
@@ -170,16 +168,15 @@ private fun VisibleButton(
 
 @Composable
 private fun Modifier.visibleBackground(): Modifier {
-    // Dark background with white border - visible on any page color
     return this
         .shadow(8.dp, RoundedCornerShape(24.dp))
         .background(
-            color = Color(0x90111111), // Dark semi-transparent (visible on white)
+            color = Color(0x90111111),
             shape = RoundedCornerShape(24.dp)
         )
         .border(
             width = 1.5.dp,
-            color = Color.White.copy(alpha = 0.5f), // White border for contrast
+            color = Color.White.copy(alpha = 0.5f),
             shape = RoundedCornerShape(24.dp)
         )
 }

--- a/app/src/main/java/com/lockit/ui/components/DraggableFloatingButtons.kt
+++ b/app/src/main/java/com/lockit/ui/components/DraggableFloatingButtons.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -36,8 +35,9 @@ import com.lockit.R
 import kotlin.math.roundToInt
 
 /**
- * Draggable floating button container with left/right snap toggle.
- * Uses MATCH_PARENT with touch passthrough for proper drag support.
+ * Draggable floating button container.
+ * Uses MATCH_PARENT to cover full screen for drag support.
+ * Initial position: right side, middle of screen.
  */
 class DraggableFloatingButtons(
     private val onBack: () -> Unit,
@@ -66,103 +66,90 @@ private fun FloatingButtonsContent(
     val screenWidthPx = with(density) { configuration.screenWidthDp.dp.toPx() }
     val screenHeightPx = with(density) { configuration.screenHeightDp.dp.toPx() }
 
-    // Button size estimates
-    val buttonWidthPx = remember { mutableStateOf(100f) }
-    val buttonHeightPx = remember { mutableStateOf(104f) }
+    // Button dimensions (measured after layout)
+    val buttonWidthPx = remember { mutableStateOf(200f) }
+    val buttonHeightPx = remember { mutableStateOf(120f) }
 
-    // Initialization flag
-    val isInitialized = remember { mutableStateOf(false) }
+    // Initial position: right edge, middle of screen
+    val offsetX = remember { mutableStateOf(screenWidthPx - buttonWidthPx.value - 32f) }
+    val offsetY = remember { mutableStateOf(screenHeightPx / 2f) }
 
-    // Left/right side toggle
+    // Left/right snap toggle
     val isOnRight = remember { mutableStateOf(true) }
-
-    // Position: relative offset from gravity anchor (TOP|END)
-    // offsetX: 0 = right edge, negative = moves left
-    // offsetY: 0 = top margin, positive = moves down
-    // Initialize near gravity anchor position so onGloballyPositioned fires
-    val offsetX = remember { mutableStateOf(0f) }
-    val offsetY = remember { mutableStateOf(0f) }  // Start at top margin position
-
-    fun safeCoerceIn(value: Float, min: Float, max: Float): Float {
-        return if (min <= max) value.coerceIn(min, max) else value
-    }
 
     fun snapToSide(right: Boolean) {
         isOnRight.value = right
         val btnW = buttonWidthPx.value
-        offsetX.value = if (right) 0f else -(screenWidthPx - btnW - 32f)
+        offsetX.value = if (right) screenWidthPx - btnW - 32f else 32f
     }
 
-    // Button container - positioned relative to gravity anchor
+    // Transparent full-screen container for touch passthrough
     Box(
         modifier = Modifier
-            .onGloballyPositioned { coordinates ->
-                buttonWidthPx.value = coordinates.size.width.toFloat()
-                buttonHeightPx.value = coordinates.size.height.toFloat()
-                if (!isInitialized.value) {
-                    isInitialized.value = true
-                    // Center Y position after measurement
-                    offsetY.value = screenHeightPx / 2 - coordinates.size.height / 2 - 100f
-                }
-            }
-            // Only apply offset after initialization to ensure onGloballyPositioned fires
-            .offset {
-                if (isInitialized.value) {
-                    IntOffset(offsetX.value.roundToInt(), offsetY.value.roundToInt())
-                } else {
-                    IntOffset.Zero  // Start at gravity anchor position
-                }
-            }
-            .pointerInput(configuration.screenWidthDp, configuration.screenHeightDp) {
-                detectDragGestures { change, dragAmount ->
-                    change.consume()
-                    val btnW = buttonWidthPx.value
-                    val btnH = buttonHeightPx.value
-                    val newX = offsetX.value + dragAmount.x
-                    val newY = offsetY.value + dragAmount.y
-                    // Clamp: X from 0 (right) to -(screenWidth-btnW-32) (left)
-                    offsetX.value = safeCoerceIn(newX, -(screenWidthPx - btnW - 32f), 0f)
-                    offsetY.value = safeCoerceIn(newY, 0f, screenHeightPx - btnH - 100f)
-                }
-            }
-            .visibleBackground()
-            .padding(8.dp)
+            .fillMaxSize()
+            .background(Color.Transparent)
     ) {
-        Column {
-            Row {
-                VisibleButton(
-                    iconRes = R.drawable.ic_swap_horiz,
-                    contentDescription = "切换位置",
-                    onClick = { snapToSide(!isOnRight.value) },
-                    backgroundColor = Color(0x80B34700),
-                    iconColor = Color.White
-                )
-                Spacer(modifier = Modifier.width(4.dp))
-                VisibleButton(
-                    iconRes = R.drawable.ic_arrow_back,
-                    contentDescription = "返回",
-                    onClick = onBack,
-                    backgroundColor = Color(0x80111111),
-                    iconColor = Color.White
-                )
-            }
-            Spacer(modifier = Modifier.padding(4.dp))
-            Row {
-                VisibleButton(
-                    iconRes = R.drawable.ic_refresh,
-                    contentDescription = "重新登录",
-                    onClick = onReset,
-                    backgroundColor = Color(0x80B34700),
-                    iconColor = Color.White
-                )
-                Spacer(modifier = Modifier.width(4.dp))
-                VisibleButton(
-                    iconRes = R.drawable.ic_close,
-                    contentDescription = "关闭",
-                    onClick = onClose,
-                    backgroundColor = Color(0x80A30000),
-                    iconColor = Color.White
-                )
+        // Button container - positioned inside the full-screen overlay
+        Box(
+            modifier = Modifier
+                .onGloballyPositioned { coordinates ->
+                    buttonWidthPx.value = coordinates.size.width.toFloat()
+                    buttonHeightPx.value = coordinates.size.height.toFloat()
+                    // Adjust initial position after first measurement
+                    if (offsetX.value > screenWidthPx - coordinates.size.width - 32f) {
+                        offsetX.value = screenWidthPx - coordinates.size.width - 32f
+                    }
+                }
+                .offset { IntOffset(offsetX.value.roundToInt(), offsetY.value.roundToInt()) }
+                .pointerInput(Unit) {
+                    detectDragGestures { change, dragAmount ->
+                        change.consume()
+                        val newX = offsetX.value + dragAmount.x
+                        val newY = offsetY.value + dragAmount.y
+                        // Clamp to screen bounds
+                        offsetX.value = newX.coerceIn(0f, screenWidthPx - buttonWidthPx.value)
+                        offsetY.value = newY.coerceIn(0f, screenHeightPx - buttonHeightPx.value)
+                    }
+                }
+                .visibleBackground()
+                .padding(8.dp)
+        ) {
+            Column {
+                Row {
+                    VisibleButton(
+                        iconRes = R.drawable.ic_swap_horiz,
+                        contentDescription = "切换位置",
+                        onClick = { snapToSide(!isOnRight.value) },
+                        backgroundColor = Color(0x80B34700),
+                        iconColor = Color.White
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    VisibleButton(
+                        iconRes = R.drawable.ic_arrow_back,
+                        contentDescription = "返回",
+                        onClick = onBack,
+                        backgroundColor = Color(0x80111111),
+                        iconColor = Color.White
+                    )
+                }
+                Spacer(modifier = Modifier.padding(4.dp))
+                Row {
+                    VisibleButton(
+                        iconRes = R.drawable.ic_refresh,
+                        contentDescription = "重新登录",
+                        onClick = onReset,
+                        backgroundColor = Color(0x80B34700),
+                        iconColor = Color.White
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    VisibleButton(
+                        iconRes = R.drawable.ic_close,
+                        contentDescription = "关闭",
+                        onClick = onClose,
+                        backgroundColor = Color(0x80A30000),
+                        iconColor = Color.White
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/lockit/ui/components/DraggableFloatingButtons.kt
+++ b/app/src/main/java/com/lockit/ui/components/DraggableFloatingButtons.kt
@@ -66,58 +66,46 @@ private fun FloatingButtonsContent(
     val screenWidthPx = with(density) { configuration.screenWidthDp.dp.toPx() }
     val screenHeightPx = with(density) { configuration.screenHeightDp.dp.toPx() }
 
-    // Actual measured button size (not hardcoded)
-    val buttonWidthPx = remember { mutableStateOf(0f) }
-    val buttonHeightPx = remember { mutableStateOf(0f) }
+    // Actual measured button size
+    val buttonWidthPx = remember { mutableStateOf(100f) } // Default estimate
+    val buttonHeightPx = remember { mutableStateOf(104f) } // Default estimate (40+40+4+8+8)
+
+    // Initialization flag
+    val isInitialized = remember { mutableStateOf(false) }
 
     // Left/right side toggle state
     val isOnRight = remember { mutableStateOf(true) }
 
-    // Position: absolute screen coordinates
-    val offsetX = remember { mutableStateOf(screenWidthPx - 100f) }
-    val offsetY = remember { mutableStateOf(screenHeightPx / 2) }
+    // Position: absolute screen coordinates (start with estimated visible position)
+    val offsetX = remember { mutableStateOf(screenWidthPx - 120f) }
+    val offsetY = remember { mutableStateOf(screenHeightPx / 2 - 60f) }
 
-    // Recalculate position on config change (rotation, split-screen)
-    LaunchedEffect(configuration.screenWidthDp, configuration.screenHeightDp, buttonWidthPx.value, buttonHeightPx.value) {
-        // Snap to correct side after rotation
-        val btnW = buttonWidthPx.value
-        val btnH = buttonHeightPx.value
-        if (btnW > 0 && btnH > 0) {
-            if (isOnRight.value) {
-                offsetX.value = screenWidthPx - btnW - 16f
-            } else {
-                offsetX.value = 16f
-            }
-            // Ensure Y is in bounds
-            offsetY.value = offsetY.value.coerceIn(0f, screenHeightPx - btnH - 50f)
-        }
+    // Safe coerceIn
+    fun safeCoerceIn(value: Float, min: Float, max: Float): Float {
+        return if (min <= max) value.coerceIn(min, max) else value
     }
 
     // Snap to side function
     fun snapToSide(right: Boolean) {
         isOnRight.value = right
         val btnW = buttonWidthPx.value
-        if (btnW > 0) {
-            offsetX.value = if (right) screenWidthPx - btnW - 16f else 16f
-        }
+        offsetX.value = if (right) safeCoerceIn(screenWidthPx - btnW - 16f, 0f, screenWidthPx) else 16f
     }
 
-    // Safe coerceIn (handles case where min > max)
-    fun safeCoerceIn(value: Float, min: Float, max: Float): Float {
-        return if (min <= max) value.coerceIn(min, max) else if (value < min) min else if (value > max) max else value
-    }
-
-    // Full-screen container with measured button box
+    // Full-screen container
     Box(modifier = Modifier.fillMaxSize()) {
         Box(
             modifier = Modifier
                 .onGloballyPositioned { coordinates ->
-                    buttonWidthPx.value = coordinates.size.width.toFloat()
-                    buttonHeightPx.value = coordinates.size.height.toFloat()
+                    val w = coordinates.size.width.toFloat()
+                    val h = coordinates.size.height.toFloat()
+                    buttonWidthPx.value = w
+                    buttonHeightPx.value = h
                     // Initialize position on first measure
-                    if (offsetX.value == screenWidthPx - 100f) {
-                        offsetX.value = screenWidthPx - coordinates.size.width - 16f
-                        offsetY.value = screenHeightPx / 2 - coordinates.size.height / 2
+                    if (!isInitialized.value) {
+                        isInitialized.value = true
+                        offsetX.value = screenWidthPx - w - 16f
+                        offsetY.value = screenHeightPx / 2 - h / 2
                     }
                 }
                 .offset { IntOffset(offsetX.value.roundToInt(), offsetY.value.roundToInt()) }
@@ -126,12 +114,10 @@ private fun FloatingButtonsContent(
                         change.consume()
                         val btnW = buttonWidthPx.value
                         val btnH = buttonHeightPx.value
-                        if (btnW > 0 && btnH > 0) {
-                            val newX = offsetX.value + dragAmount.x
-                            val newY = offsetY.value + dragAmount.y
-                            offsetX.value = safeCoerceIn(newX, 0f, screenWidthPx - btnW)
-                            offsetY.value = safeCoerceIn(newY, 50f, screenHeightPx - btnH - 50f)
-                        }
+                        val newX = offsetX.value + dragAmount.x
+                        val newY = offsetY.value + dragAmount.y
+                        offsetX.value = safeCoerceIn(newX, 0f, screenWidthPx - btnW)
+                        offsetY.value = safeCoerceIn(newY, 50f, screenHeightPx - btnH - 50f)
                     }
                 }
                 .visibleBackground()

--- a/app/src/main/java/com/lockit/ui/components/DraggableFloatingButtons.kt
+++ b/app/src/main/java/com/lockit/ui/components/DraggableFloatingButtons.kt
@@ -6,10 +6,13 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
@@ -62,8 +65,8 @@ private fun FloatingButtonsContent(
     val configuration = androidx.compose.ui.platform.LocalConfiguration.current
     val screenWidthPx = with(density) { configuration.screenWidthDp.dp.toPx() }
     val screenHeightPx = with(density) { configuration.screenHeightDp.dp.toPx() }
-    val buttonWidthPx = with(density) { 180.dp.toPx() }
-    val buttonHeightPx = with(density) { 56.dp.toPx() }
+    val buttonWidthPx = with(density) { 88.dp.toPx() }  // 2 buttons + spacing
+    val buttonHeightPx = with(density) { 96.dp.toPx() } // 2 rows + spacing
 
     // Left/right side toggle state
     val isOnRight = remember { mutableStateOf(true) }
@@ -97,8 +100,6 @@ private fun FloatingButtonsContent(
                     change.consume()
                     val newX = offsetX.value + dragAmount.x
                     val newY = offsetY.value + dragAmount.y
-                    // Clamp: can move from right (0) to left (-screenWidth+buttonWidth+32)
-                    // Y: 0 to screenHeight - buttonHeight - 100
                     offsetX.value = newX.coerceIn(-(screenWidthPx - buttonWidthPx - 32f), 0f)
                     offsetY.value = newY.coerceIn(0f, screenHeightPx - buttonHeightPx - 100f)
                 }
@@ -106,35 +107,43 @@ private fun FloatingButtonsContent(
             .visibleBackground()
             .padding(8.dp)
     ) {
-        Row {
-            VisibleButton(
-                iconRes = R.drawable.ic_swap_horiz,
-                contentDescription = "切换位置",
-                onClick = { snapToSide(!isOnRight.value) },
-                backgroundColor = Color(0x80B34700),
-                iconColor = Color.White
-            )
-            VisibleButton(
-                iconRes = R.drawable.ic_arrow_back,
-                contentDescription = "返回",
-                onClick = onBack,
-                backgroundColor = Color(0x80111111),
-                iconColor = Color.White
-            )
-            VisibleButton(
-                iconRes = R.drawable.ic_refresh,
-                contentDescription = "重新登录",
-                onClick = onReset,
-                backgroundColor = Color(0x80B34700),
-                iconColor = Color.White
-            )
-            VisibleButton(
-                iconRes = R.drawable.ic_close,
-                contentDescription = "关闭",
-                onClick = onClose,
-                backgroundColor = Color(0x80A30000),
-                iconColor = Color.White
-            )
+        // 2x2 grid layout
+        Column {
+            Row {
+                VisibleButton(
+                    iconRes = R.drawable.ic_swap_horiz,
+                    contentDescription = "切换位置",
+                    onClick = { snapToSide(!isOnRight.value) },
+                    backgroundColor = Color(0x80B34700),
+                    iconColor = Color.White
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                VisibleButton(
+                    iconRes = R.drawable.ic_arrow_back,
+                    contentDescription = "返回",
+                    onClick = onBack,
+                    backgroundColor = Color(0x80111111),
+                    iconColor = Color.White
+                )
+            }
+            Spacer(modifier = Modifier.padding(4.dp))
+            Row {
+                VisibleButton(
+                    iconRes = R.drawable.ic_refresh,
+                    contentDescription = "重新登录",
+                    onClick = onReset,
+                    backgroundColor = Color(0x80B34700),
+                    iconColor = Color.White
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                VisibleButton(
+                    iconRes = R.drawable.ic_close,
+                    contentDescription = "关闭",
+                    onClick = onClose,
+                    backgroundColor = Color(0x80A30000),
+                    iconColor = Color.White
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/lockit/ui/components/DraggableFloatingButtons.kt
+++ b/app/src/main/java/com/lockit/ui/components/DraggableFloatingButtons.kt
@@ -66,99 +66,103 @@ private fun FloatingButtonsContent(
     val screenWidthPx = with(density) { configuration.screenWidthDp.dp.toPx() }
     val screenHeightPx = with(density) { configuration.screenHeightDp.dp.toPx() }
 
-    // Actual measured button size
-    val buttonWidthPx = remember { mutableStateOf(100f) } // Default estimate
-    val buttonHeightPx = remember { mutableStateOf(104f) } // Default estimate (40+40+4+8+8)
+    // Button size estimates
+    val buttonWidthPx = remember { mutableStateOf(100f) }
+    val buttonHeightPx = remember { mutableStateOf(104f) }
 
     // Initialization flag
     val isInitialized = remember { mutableStateOf(false) }
 
-    // Left/right side toggle state
+    // Left/right side toggle
     val isOnRight = remember { mutableStateOf(true) }
 
-    // Position: absolute screen coordinates (start with estimated visible position)
-    val offsetX = remember { mutableStateOf(screenWidthPx - 120f) }
-    val offsetY = remember { mutableStateOf(screenHeightPx / 2 - 60f) }
+    // Position: relative offset from gravity anchor (TOP|END)
+    // offsetX: 0 = right edge, negative = moves left
+    // offsetY: 0 = top margin, positive = moves down
+    // Initialize near gravity anchor position so onGloballyPositioned fires
+    val offsetX = remember { mutableStateOf(0f) }
+    val offsetY = remember { mutableStateOf(0f) }  // Start at top margin position
 
-    // Safe coerceIn
     fun safeCoerceIn(value: Float, min: Float, max: Float): Float {
         return if (min <= max) value.coerceIn(min, max) else value
     }
 
-    // Snap to side function
     fun snapToSide(right: Boolean) {
         isOnRight.value = right
         val btnW = buttonWidthPx.value
-        offsetX.value = if (right) safeCoerceIn(screenWidthPx - btnW - 16f, 0f, screenWidthPx) else 16f
+        offsetX.value = if (right) 0f else -(screenWidthPx - btnW - 32f)
     }
 
-    // Full-screen container
-    Box(modifier = Modifier.fillMaxSize()) {
-        Box(
-            modifier = Modifier
-                .onGloballyPositioned { coordinates ->
-                    val w = coordinates.size.width.toFloat()
-                    val h = coordinates.size.height.toFloat()
-                    buttonWidthPx.value = w
-                    buttonHeightPx.value = h
-                    // Initialize position on first measure
-                    if (!isInitialized.value) {
-                        isInitialized.value = true
-                        offsetX.value = screenWidthPx - w - 16f
-                        offsetY.value = screenHeightPx / 2 - h / 2
-                    }
+    // Button container - positioned relative to gravity anchor
+    Box(
+        modifier = Modifier
+            .onGloballyPositioned { coordinates ->
+                buttonWidthPx.value = coordinates.size.width.toFloat()
+                buttonHeightPx.value = coordinates.size.height.toFloat()
+                if (!isInitialized.value) {
+                    isInitialized.value = true
+                    // Center Y position after measurement
+                    offsetY.value = screenHeightPx / 2 - coordinates.size.height / 2 - 100f
                 }
-                .offset { IntOffset(offsetX.value.roundToInt(), offsetY.value.roundToInt()) }
-                .pointerInput(configuration.screenWidthDp, configuration.screenHeightDp) {
-                    detectDragGestures { change, dragAmount ->
-                        change.consume()
-                        val btnW = buttonWidthPx.value
-                        val btnH = buttonHeightPx.value
-                        val newX = offsetX.value + dragAmount.x
-                        val newY = offsetY.value + dragAmount.y
-                        offsetX.value = safeCoerceIn(newX, 0f, screenWidthPx - btnW)
-                        offsetY.value = safeCoerceIn(newY, 50f, screenHeightPx - btnH - 50f)
-                    }
+            }
+            // Only apply offset after initialization to ensure onGloballyPositioned fires
+            .offset {
+                if (isInitialized.value) {
+                    IntOffset(offsetX.value.roundToInt(), offsetY.value.roundToInt())
+                } else {
+                    IntOffset.Zero  // Start at gravity anchor position
                 }
-                .visibleBackground()
-                .padding(8.dp)
-        ) {
-            Column {
-                Row {
-                    VisibleButton(
-                        iconRes = R.drawable.ic_swap_horiz,
-                        contentDescription = "切换位置",
-                        onClick = { snapToSide(!isOnRight.value) },
-                        backgroundColor = Color(0x80B34700),
-                        iconColor = Color.White
-                    )
-                    Spacer(modifier = Modifier.width(4.dp))
-                    VisibleButton(
-                        iconRes = R.drawable.ic_arrow_back,
-                        contentDescription = "返回",
-                        onClick = onBack,
-                        backgroundColor = Color(0x80111111),
-                        iconColor = Color.White
-                    )
+            }
+            .pointerInput(configuration.screenWidthDp, configuration.screenHeightDp) {
+                detectDragGestures { change, dragAmount ->
+                    change.consume()
+                    val btnW = buttonWidthPx.value
+                    val btnH = buttonHeightPx.value
+                    val newX = offsetX.value + dragAmount.x
+                    val newY = offsetY.value + dragAmount.y
+                    // Clamp: X from 0 (right) to -(screenWidth-btnW-32) (left)
+                    offsetX.value = safeCoerceIn(newX, -(screenWidthPx - btnW - 32f), 0f)
+                    offsetY.value = safeCoerceIn(newY, 0f, screenHeightPx - btnH - 100f)
                 }
-                Spacer(modifier = Modifier.padding(4.dp))
-                Row {
-                    VisibleButton(
-                        iconRes = R.drawable.ic_refresh,
-                        contentDescription = "重新登录",
-                        onClick = onReset,
-                        backgroundColor = Color(0x80B34700),
-                        iconColor = Color.White
-                    )
-                    Spacer(modifier = Modifier.width(4.dp))
-                    VisibleButton(
-                        iconRes = R.drawable.ic_close,
-                        contentDescription = "关闭",
-                        onClick = onClose,
-                        backgroundColor = Color(0x80A30000),
-                        iconColor = Color.White
-                    )
-                }
+            }
+            .visibleBackground()
+            .padding(8.dp)
+    ) {
+        Column {
+            Row {
+                VisibleButton(
+                    iconRes = R.drawable.ic_swap_horiz,
+                    contentDescription = "切换位置",
+                    onClick = { snapToSide(!isOnRight.value) },
+                    backgroundColor = Color(0x80B34700),
+                    iconColor = Color.White
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                VisibleButton(
+                    iconRes = R.drawable.ic_arrow_back,
+                    contentDescription = "返回",
+                    onClick = onBack,
+                    backgroundColor = Color(0x80111111),
+                    iconColor = Color.White
+                )
+            }
+            Spacer(modifier = Modifier.padding(4.dp))
+            Row {
+                VisibleButton(
+                    iconRes = R.drawable.ic_refresh,
+                    contentDescription = "重新登录",
+                    onClick = onReset,
+                    backgroundColor = Color(0x80B34700),
+                    iconColor = Color.White
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                VisibleButton(
+                    iconRes = R.drawable.ic_close,
+                    contentDescription = "关闭",
+                    onClick = onClose,
+                    backgroundColor = Color(0x80A30000),
+                    iconColor = Color.White
+                )
             }
         }
     }

--- a/app/src/main/java/com/lockit/ui/components/DraggableFloatingButtons.kt
+++ b/app/src/main/java/com/lockit/ui/components/DraggableFloatingButtons.kt
@@ -36,7 +36,7 @@ import com.lockit.ui.theme.TacticalRed
 import kotlin.math.roundToInt
 
 /**
- * Draggable floating button container with visible styling.
+ * Draggable floating button container with left/right snap toggle.
  * Used in WebViewAuthActivity for overlay controls.
  */
 class DraggableFloatingButtons(
@@ -69,12 +69,21 @@ private fun FloatingButtonsContent(
     val screenHeightPx = with(density) {
         androidx.compose.ui.platform.LocalConfiguration.current.screenHeightDp.dp.toPx()
     }
-    val buttonWidthPx = with(density) { 140.dp.toPx() }
+    val buttonWidthPx = with(density) { 180.dp.toPx() } // Increased for 4 buttons
     val buttonHeightPx = with(density) { 56.dp.toPx() }
 
-    // Initial position: top-right corner with margin
-    val offsetX = remember { mutableStateOf(screenWidthPx - buttonWidthPx - 32f) }
-    val offsetY = remember { mutableStateOf(80f) }
+    // Left/right side toggle state
+    val isOnRight = remember { mutableStateOf(true) }
+
+    // Position: initially right-middle
+    val offsetX = remember { mutableStateOf(screenWidthPx - buttonWidthPx - 16f) }
+    val offsetY = remember { mutableStateOf(screenHeightPx / 2 - buttonHeightPx / 2) }
+
+    // Snap to side function
+    fun snapToSide(right: Boolean) {
+        isOnRight.value = right
+        offsetX.value = if (right) screenWidthPx - buttonWidthPx - 16f else 16f
+    }
 
     // Full-screen transparent container for touch capture
     Box(
@@ -98,6 +107,14 @@ private fun FloatingButtonsContent(
                 .padding(8.dp)
         ) {
             Row {
+                // Toggle position button (left/right snap)
+                VisibleButton(
+                    iconRes = R.drawable.ic_swap_horiz,
+                    contentDescription = "切换位置",
+                    onClick = { snapToSide(!isOnRight.value) },
+                    backgroundColor = Color(0x80B34700),
+                    iconColor = Color.White
+                )
                 VisibleButton(
                     iconRes = R.drawable.ic_arrow_back,
                     contentDescription = "返回",

--- a/app/src/main/java/com/lockit/ui/components/DraggableFloatingButtons.kt
+++ b/app/src/main/java/com/lockit/ui/components/DraggableFloatingButtons.kt
@@ -13,11 +13,10 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -32,12 +31,14 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.lockit.R
+import com.lockit.ui.theme.RectangleShape
 import kotlin.math.roundToInt
 
 /**
  * Draggable floating button container.
  * Uses MATCH_PARENT to cover full screen for drag support.
  * Initial position: right side, middle of screen.
+ * Technical Brutalism: RectangleShape, 1px black borders.
  */
 class DraggableFloatingButtons(
     private val onBack: () -> Unit,
@@ -67,23 +68,40 @@ private fun FloatingButtonsContent(
     val screenHeightPx = with(density) { configuration.screenHeightDp.dp.toPx() }
 
     // Button dimensions (measured after layout)
-    val buttonWidthPx = remember { mutableStateOf(200f) }
-    val buttonHeightPx = remember { mutableStateOf(120f) }
+    val buttonWidthPx = remember { mutableStateOf(0f) }
+    val buttonHeightPx = remember { mutableStateOf(0f) }
+    val isInitialized = remember { mutableStateOf(false) }
 
-    // Initial position: right edge, middle of screen
-    val offsetX = remember { mutableStateOf(screenWidthPx - buttonWidthPx.value - 32f) }
+    // Position states - start at right edge, middle of screen
+    val offsetX = remember { mutableStateOf(screenWidthPx) }
     val offsetY = remember { mutableStateOf(screenHeightPx / 2f) }
 
     // Left/right snap toggle
     val isOnRight = remember { mutableStateOf(true) }
 
+    // Re-clamp positions when screen size changes (orientation change)
+    LaunchedEffect(screenWidthPx, screenHeightPx) {
+        if (isInitialized.value && buttonWidthPx.value > 0 && buttonHeightPx.value > 0) {
+            val maxX = (screenWidthPx - buttonWidthPx.value).coerceAtLeast(0f)
+            val maxY = (screenHeightPx - buttonHeightPx.value).coerceAtLeast(0f)
+            offsetX.value = offsetX.value.coerceIn(0f, maxX)
+            offsetY.value = offsetY.value.coerceIn(0f, maxY)
+        }
+    }
+
+    fun safeCoerceIn(value: Float, min: Float, max: Float): Float {
+        return if (max >= min) value.coerceIn(min, max) else min
+    }
+
     fun snapToSide(right: Boolean) {
         isOnRight.value = right
         val btnW = buttonWidthPx.value
-        offsetX.value = if (right) screenWidthPx - btnW - 32f else 32f
+        val maxX = (screenWidthPx - btnW - 32f).coerceAtLeast(0f)
+        offsetX.value = safeCoerceIn(if (right) maxX else 32f, 0f, maxX)
     }
 
-    // Transparent full-screen container for touch passthrough
+    // Transparent full-screen container - touches pass through to WebView outside button area
+    // The Box with transparent background naturally passes non-consumed touches to underlying views
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -95,9 +113,12 @@ private fun FloatingButtonsContent(
                 .onGloballyPositioned { coordinates ->
                     buttonWidthPx.value = coordinates.size.width.toFloat()
                     buttonHeightPx.value = coordinates.size.height.toFloat()
-                    // Adjust initial position after first measurement
-                    if (offsetX.value > screenWidthPx - coordinates.size.width - 32f) {
-                        offsetX.value = screenWidthPx - coordinates.size.width - 32f
+                    // Set initial position after first measurement
+                    if (!isInitialized.value) {
+                        val maxX = (screenWidthPx - coordinates.size.width - 32f).coerceAtLeast(0f)
+                        offsetX.value = maxX
+                        offsetY.value = (screenHeightPx / 2f).coerceIn(0f, (screenHeightPx - coordinates.size.height).coerceAtLeast(0f))
+                        isInitialized.value = true
                     }
                 }
                 .offset { IntOffset(offsetX.value.roundToInt(), offsetY.value.roundToInt()) }
@@ -106,9 +127,11 @@ private fun FloatingButtonsContent(
                         change.consume()
                         val newX = offsetX.value + dragAmount.x
                         val newY = offsetY.value + dragAmount.y
-                        // Clamp to screen bounds
-                        offsetX.value = newX.coerceIn(0f, screenWidthPx - buttonWidthPx.value)
-                        offsetY.value = newY.coerceIn(0f, screenHeightPx - buttonHeightPx.value)
+                        // Safe clamp to screen bounds (avoid empty range crash)
+                        val maxX = (screenWidthPx - buttonWidthPx.value).coerceAtLeast(0f)
+                        val maxY = (screenHeightPx - buttonHeightPx.value).coerceAtLeast(0f)
+                        offsetX.value = newX.coerceIn(0f, maxX)
+                        offsetY.value = newY.coerceIn(0f, maxY)
                     }
                 }
                 .visibleBackground()
@@ -163,15 +186,16 @@ private fun VisibleButton(
     backgroundColor: Color,
     iconColor: Color,
 ) {
+    // Technical Brutalism: RectangleShape, 1px black borders
     IconButton(
         onClick = onClick,
         modifier = Modifier
             .size(40.dp)
             .background(
                 color = backgroundColor,
-                shape = CircleShape
+                shape = RectangleShape
             )
-            .border(1.dp, Color.White.copy(alpha = 0.3f), CircleShape)
+            .border(1.dp, Color.Black, RectangleShape)
     ) {
         Icon(
             painter = painterResource(id = iconRes),
@@ -184,15 +208,16 @@ private fun VisibleButton(
 
 @Composable
 private fun Modifier.visibleBackground(): Modifier {
+    // Technical Brutalism: 0px corners, 1px black border
     return this
-        .shadow(8.dp, RoundedCornerShape(24.dp))
+        .shadow(4.dp, RectangleShape)
         .background(
             color = Color(0x90111111),
-            shape = RoundedCornerShape(24.dp)
+            shape = RectangleShape
         )
         .border(
-            width = 1.5.dp,
-            color = Color.White.copy(alpha = 0.5f),
-            shape = RoundedCornerShape(24.dp)
+            width = 1.dp,
+            color = Color.Black,
+            shape = RectangleShape
         )
 }

--- a/app/src/main/java/com/lockit/ui/components/DraggableFloatingButtons.kt
+++ b/app/src/main/java/com/lockit/ui/components/DraggableFloatingButtons.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -60,9 +61,6 @@ private fun FloatingButtonsContent(
     onReset: () -> Unit,
     onClose: () -> Unit,
 ) {
-    val offsetX = remember { mutableStateOf(0f) }
-    val offsetY = remember { mutableStateOf(0f) }
-
     // Get screen bounds for clamping
     val density = LocalDensity.current
     val screenWidthPx = with(density) {
@@ -71,53 +69,57 @@ private fun FloatingButtonsContent(
     val screenHeightPx = with(density) {
         androidx.compose.ui.platform.LocalConfiguration.current.screenHeightDp.dp.toPx()
     }
-    val buttonWidthPx = with(density) { 140.dp.toPx() } // Approximate button container width
-    val buttonHeightPx = with(density) { 56.dp.toPx() } // Approximate button container height
+    val buttonWidthPx = with(density) { 140.dp.toPx() }
+    val buttonHeightPx = with(density) { 56.dp.toPx() }
 
+    // Initial position: top-right corner with margin
+    val offsetX = remember { mutableStateOf(screenWidthPx - buttonWidthPx - 32f) }
+    val offsetY = remember { mutableStateOf(80f) }
+
+    // Full-screen transparent container for touch capture
     Box(
-        modifier = Modifier
-            .offset { IntOffset(offsetX.value.roundToInt(), offsetY.value.roundToInt()) }
-            .pointerInput(Unit) {
-                detectDragGestures { change, dragAmount ->
-                    change.consume()
-                    // Update position and clamp to screen bounds
-                    val newX = offsetX.value + dragAmount.x
-                    val newY = offsetY.value + dragAmount.y
-                    // Clamp to keep buttons visible on screen
-                    offsetX.value = newX.coerceIn(-screenWidthPx + buttonWidthPx / 2, screenWidthPx - buttonWidthPx)
-                    offsetY.value = newY.coerceIn(-100f, screenHeightPx - buttonHeightPx - 100f)
-                }
-            }
-            .visibleBackground()
-            .padding(8.dp)
+        modifier = Modifier.fillMaxSize()
     ) {
-        Row {
-            // Back button
-            VisibleButton(
-                iconRes = R.drawable.ic_arrow_back,
-                contentDescription = "返回",
-                onClick = onBack,
-                backgroundColor = Color(0x80111111),
-                iconColor = Color.White
-            )
-
-            // Reset button
-            VisibleButton(
-                iconRes = R.drawable.ic_refresh,
-                contentDescription = "重新登录",
-                onClick = onReset,
-                backgroundColor = Color(0x80B34700),
-                iconColor = Color.White
-            )
-
-            // Close button
-            VisibleButton(
-                iconRes = R.drawable.ic_close,
-                contentDescription = "关闭",
-                onClick = onClose,
-                backgroundColor = Color(0x80A30000),
-                iconColor = Color.White
-            )
+        // Positioned button container (draggable anywhere)
+        Box(
+            modifier = Modifier
+                .offset { IntOffset(offsetX.value.roundToInt(), offsetY.value.roundToInt()) }
+                .pointerInput(Unit) {
+                    detectDragGestures { change, dragAmount ->
+                        change.consume()
+                        val newX = offsetX.value + dragAmount.x
+                        val newY = offsetY.value + dragAmount.y
+                        // Clamp to keep buttons visible
+                        offsetX.value = newX.coerceIn(0f, screenWidthPx - buttonWidthPx)
+                        offsetY.value = newY.coerceIn(0f, screenHeightPx - buttonHeightPx)
+                    }
+                }
+                .visibleBackground()
+                .padding(8.dp)
+        ) {
+            Row {
+                VisibleButton(
+                    iconRes = R.drawable.ic_arrow_back,
+                    contentDescription = "返回",
+                    onClick = onBack,
+                    backgroundColor = Color(0x80111111),
+                    iconColor = Color.White
+                )
+                VisibleButton(
+                    iconRes = R.drawable.ic_refresh,
+                    contentDescription = "重新登录",
+                    onClick = onReset,
+                    backgroundColor = Color(0x80B34700),
+                    iconColor = Color.White
+                )
+                VisibleButton(
+                    iconRes = R.drawable.ic_close,
+                    contentDescription = "关闭",
+                    onClick = onClose,
+                    backgroundColor = Color(0x80A30000),
+                    iconColor = Color.White
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/lockit/ui/components/DraggableFloatingButtons.kt
+++ b/app/src/main/java/com/lockit/ui/components/DraggableFloatingButtons.kt
@@ -1,6 +1,5 @@
 package com.lockit.ui.components
 
-import android.os.Build
 import android.view.View
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -9,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -25,6 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.platform.LocalDensity
@@ -36,7 +37,7 @@ import kotlin.math.roundToInt
 
 /**
  * Draggable floating button container with left/right snap toggle.
- * Used in WebViewAuthActivity for overlay controls.
+ * Uses MATCH_PARENT with touch passthrough for proper drag support.
  */
 class DraggableFloatingButtons(
     private val onBack: () -> Unit,
@@ -60,89 +61,118 @@ private fun FloatingButtonsContent(
     onReset: () -> Unit,
     onClose: () -> Unit,
 ) {
-    // Get screen bounds for clamping (recalculated on config change)
     val density = LocalDensity.current
     val configuration = androidx.compose.ui.platform.LocalConfiguration.current
     val screenWidthPx = with(density) { configuration.screenWidthDp.dp.toPx() }
     val screenHeightPx = with(density) { configuration.screenHeightDp.dp.toPx() }
-    val buttonWidthPx = with(density) { 88.dp.toPx() }  // 2 buttons + spacing
-    val buttonHeightPx = with(density) { 96.dp.toPx() } // 2 rows + spacing
+
+    // Actual measured button size (not hardcoded)
+    val buttonWidthPx = remember { mutableStateOf(0f) }
+    val buttonHeightPx = remember { mutableStateOf(0f) }
 
     // Left/right side toggle state
     val isOnRight = remember { mutableStateOf(true) }
 
-    // Position: relative offset from gravity anchor (TOP|RIGHT)
-    // offsetX: 0 = right edge, negative = moves left
-    // offsetY: 0 = top margin (100dp), positive = moves down
-    val offsetX = remember { mutableStateOf(0f) }
-    val offsetY = remember { mutableStateOf(screenHeightPx / 2 - 100f - buttonHeightPx / 2) }
+    // Position: absolute screen coordinates
+    val offsetX = remember { mutableStateOf(screenWidthPx - 100f) }
+    val offsetY = remember { mutableStateOf(screenHeightPx / 2) }
 
-    // Recalculate Y position on screen rotation
-    LaunchedEffect(configuration.screenHeightDp) {
-        if (offsetY.value > screenHeightPx - buttonHeightPx - 100f) {
-            offsetY.value = screenHeightPx - buttonHeightPx - 100f
+    // Recalculate position on config change (rotation, split-screen)
+    LaunchedEffect(configuration.screenWidthDp, configuration.screenHeightDp, buttonWidthPx.value, buttonHeightPx.value) {
+        // Snap to correct side after rotation
+        val btnW = buttonWidthPx.value
+        val btnH = buttonHeightPx.value
+        if (btnW > 0 && btnH > 0) {
+            if (isOnRight.value) {
+                offsetX.value = screenWidthPx - btnW - 16f
+            } else {
+                offsetX.value = 16f
+            }
+            // Ensure Y is in bounds
+            offsetY.value = offsetY.value.coerceIn(0f, screenHeightPx - btnH - 50f)
         }
     }
 
     // Snap to side function
     fun snapToSide(right: Boolean) {
         isOnRight.value = right
-        // offsetX: 0 = right, -(screenWidth - buttonWidth) = left
-        offsetX.value = if (right) 0f else -(screenWidthPx - buttonWidthPx - 32f)
+        val btnW = buttonWidthPx.value
+        if (btnW > 0) {
+            offsetX.value = if (right) screenWidthPx - btnW - 16f else 16f
+        }
     }
 
-    // Button container - positioned relative to gravity anchor
-    Box(
-        modifier = Modifier
-            .offset { IntOffset(offsetX.value.roundToInt(), offsetY.value.roundToInt()) }
-            .pointerInput(Unit) {
-                detectDragGestures { change, dragAmount ->
-                    change.consume()
-                    val newX = offsetX.value + dragAmount.x
-                    val newY = offsetY.value + dragAmount.y
-                    offsetX.value = newX.coerceIn(-(screenWidthPx - buttonWidthPx - 32f), 0f)
-                    offsetY.value = newY.coerceIn(0f, screenHeightPx - buttonHeightPx - 100f)
+    // Safe coerceIn (handles case where min > max)
+    fun safeCoerceIn(value: Float, min: Float, max: Float): Float {
+        return if (min <= max) value.coerceIn(min, max) else if (value < min) min else if (value > max) max else value
+    }
+
+    // Full-screen container with measured button box
+    Box(modifier = Modifier.fillMaxSize()) {
+        Box(
+            modifier = Modifier
+                .onGloballyPositioned { coordinates ->
+                    buttonWidthPx.value = coordinates.size.width.toFloat()
+                    buttonHeightPx.value = coordinates.size.height.toFloat()
+                    // Initialize position on first measure
+                    if (offsetX.value == screenWidthPx - 100f) {
+                        offsetX.value = screenWidthPx - coordinates.size.width - 16f
+                        offsetY.value = screenHeightPx / 2 - coordinates.size.height / 2
+                    }
                 }
-            }
-            .visibleBackground()
-            .padding(8.dp)
-    ) {
-        // 2x2 grid layout
-        Column {
-            Row {
-                VisibleButton(
-                    iconRes = R.drawable.ic_swap_horiz,
-                    contentDescription = "切换位置",
-                    onClick = { snapToSide(!isOnRight.value) },
-                    backgroundColor = Color(0x80B34700),
-                    iconColor = Color.White
-                )
-                Spacer(modifier = Modifier.width(4.dp))
-                VisibleButton(
-                    iconRes = R.drawable.ic_arrow_back,
-                    contentDescription = "返回",
-                    onClick = onBack,
-                    backgroundColor = Color(0x80111111),
-                    iconColor = Color.White
-                )
-            }
-            Spacer(modifier = Modifier.padding(4.dp))
-            Row {
-                VisibleButton(
-                    iconRes = R.drawable.ic_refresh,
-                    contentDescription = "重新登录",
-                    onClick = onReset,
-                    backgroundColor = Color(0x80B34700),
-                    iconColor = Color.White
-                )
-                Spacer(modifier = Modifier.width(4.dp))
-                VisibleButton(
-                    iconRes = R.drawable.ic_close,
-                    contentDescription = "关闭",
-                    onClick = onClose,
-                    backgroundColor = Color(0x80A30000),
-                    iconColor = Color.White
-                )
+                .offset { IntOffset(offsetX.value.roundToInt(), offsetY.value.roundToInt()) }
+                .pointerInput(configuration.screenWidthDp, configuration.screenHeightDp) {
+                    detectDragGestures { change, dragAmount ->
+                        change.consume()
+                        val btnW = buttonWidthPx.value
+                        val btnH = buttonHeightPx.value
+                        if (btnW > 0 && btnH > 0) {
+                            val newX = offsetX.value + dragAmount.x
+                            val newY = offsetY.value + dragAmount.y
+                            offsetX.value = safeCoerceIn(newX, 0f, screenWidthPx - btnW)
+                            offsetY.value = safeCoerceIn(newY, 50f, screenHeightPx - btnH - 50f)
+                        }
+                    }
+                }
+                .visibleBackground()
+                .padding(8.dp)
+        ) {
+            Column {
+                Row {
+                    VisibleButton(
+                        iconRes = R.drawable.ic_swap_horiz,
+                        contentDescription = "切换位置",
+                        onClick = { snapToSide(!isOnRight.value) },
+                        backgroundColor = Color(0x80B34700),
+                        iconColor = Color.White
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    VisibleButton(
+                        iconRes = R.drawable.ic_arrow_back,
+                        contentDescription = "返回",
+                        onClick = onBack,
+                        backgroundColor = Color(0x80111111),
+                        iconColor = Color.White
+                    )
+                }
+                Spacer(modifier = Modifier.padding(4.dp))
+                Row {
+                    VisibleButton(
+                        iconRes = R.drawable.ic_refresh,
+                        contentDescription = "重新登录",
+                        onClick = onReset,
+                        backgroundColor = Color(0x80B34700),
+                        iconColor = Color.White
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    VisibleButton(
+                        iconRes = R.drawable.ic_close,
+                        contentDescription = "关闭",
+                        onClick = onClose,
+                        backgroundColor = Color(0x80A30000),
+                        iconColor = Color.White
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
+++ b/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
@@ -112,11 +112,15 @@ class WebViewAuthActivity : ComponentActivity() {
             }
         ).createView(this)
 
-        // No gravity anchoring - let Compose handle absolute positioning
+        // WRAP_CONTENT - buttons overlay, doesn't block WebView touch
+        // Gravity anchors to top-right, Compose handles drag offset
         val buttonLayout = FrameLayout.LayoutParams(
-            FrameLayout.LayoutParams.MATCH_PARENT,
-            FrameLayout.LayoutParams.MATCH_PARENT
-        )
+            FrameLayout.LayoutParams.WRAP_CONTENT,
+            FrameLayout.LayoutParams.WRAP_CONTENT
+        ).apply {
+            gravity = android.view.Gravity.TOP or android.view.Gravity.RIGHT
+            setMargins(16, 100, 16, 0)
+        }
 
         val webViewLayout = FrameLayout.LayoutParams(
             FrameLayout.LayoutParams.MATCH_PARENT,

--- a/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
+++ b/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
@@ -112,15 +112,12 @@ class WebViewAuthActivity : ComponentActivity() {
             }
         ).createView(this)
 
-        // WRAP_CONTENT - buttons overlay, doesn't block WebView touch
-        // Gravity anchors to top-right, Compose handles drag offset
+        // MATCH_PARENT for Compose drag offset to work properly
+        // Touch passthrough: Compose Box(fillMaxSize) only intercepts button area
         val buttonLayout = FrameLayout.LayoutParams(
-            FrameLayout.LayoutParams.WRAP_CONTENT,
-            FrameLayout.LayoutParams.WRAP_CONTENT
-        ).apply {
-            gravity = android.view.Gravity.TOP or android.view.Gravity.RIGHT
-            setMargins(16, 100, 16, 0)
-        }
+            FrameLayout.LayoutParams.MATCH_PARENT,
+            FrameLayout.LayoutParams.MATCH_PARENT
+        )
 
         val webViewLayout = FrameLayout.LayoutParams(
             FrameLayout.LayoutParams.MATCH_PARENT,

--- a/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
+++ b/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
@@ -112,14 +112,11 @@ class WebViewAuthActivity : ComponentActivity() {
             }
         ).createView(this)
 
+        // No gravity anchoring - let Compose handle absolute positioning
         val buttonLayout = FrameLayout.LayoutParams(
-            FrameLayout.LayoutParams.WRAP_CONTENT,
-            FrameLayout.LayoutParams.WRAP_CONTENT
-        ).apply {
-            // Default position: top-right with safe margin
-            gravity = android.view.Gravity.TOP or android.view.Gravity.RIGHT
-            setMargins(16, 80, 16, 0)
-        }
+            FrameLayout.LayoutParams.MATCH_PARENT,
+            FrameLayout.LayoutParams.MATCH_PARENT
+        )
 
         val webViewLayout = FrameLayout.LayoutParams(
             FrameLayout.LayoutParams.MATCH_PARENT,

--- a/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
+++ b/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
@@ -112,12 +112,14 @@ class WebViewAuthActivity : ComponentActivity() {
             }
         ).createView(this)
 
-        // MATCH_PARENT for Compose drag offset to work properly
-        // Touch passthrough: Compose Box(fillMaxSize) only intercepts button area
+        // WRAP_CONTENT with gravity - simpler and works
         val buttonLayout = FrameLayout.LayoutParams(
-            FrameLayout.LayoutParams.MATCH_PARENT,
-            FrameLayout.LayoutParams.MATCH_PARENT
-        )
+            FrameLayout.LayoutParams.WRAP_CONTENT,
+            FrameLayout.LayoutParams.WRAP_CONTENT
+        ).apply {
+            gravity = android.view.Gravity.TOP or android.view.Gravity.END
+            setMargins(16, 100, 16, 0)
+        }
 
         val webViewLayout = FrameLayout.LayoutParams(
             FrameLayout.LayoutParams.MATCH_PARENT,

--- a/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
+++ b/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
@@ -112,14 +112,11 @@ class WebViewAuthActivity : ComponentActivity() {
             }
         ).createView(this)
 
-        // WRAP_CONTENT with gravity - simpler and works
+        // MATCH_PARENT to allow full-screen drag
         val buttonLayout = FrameLayout.LayoutParams(
-            FrameLayout.LayoutParams.WRAP_CONTENT,
-            FrameLayout.LayoutParams.WRAP_CONTENT
-        ).apply {
-            gravity = android.view.Gravity.TOP or android.view.Gravity.END
-            setMargins(16, 100, 16, 0)
-        }
+            FrameLayout.LayoutParams.MATCH_PARENT,
+            FrameLayout.LayoutParams.MATCH_PARENT
+        )
 
         val webViewLayout = FrameLayout.LayoutParams(
             FrameLayout.LayoutParams.MATCH_PARENT,

--- a/app/src/main/res/drawable/ic_swap_horiz.xml
+++ b/app/src/main/res/drawable/ic_swap_horiz.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M6.99,11L3,15l3.99,4v-3H14v-2H6.99v-3zM21,9l-3.99,-4v3H10v2h7.01v3L21,9z"/>
+</vector>


### PR DESCRIPTION
## Summary
- 深色半透明背景 + 白色边框 (任何网页背景都可见)
- 添加屏幕边界 clamp，支持全屏拖动且按钮始终可见
- 每个按钮独立颜色: 返回-黑/刷新-橙/关闭-红

## 修复
- 问题1: 白色背景页面下按钮不可见 → 改为深色背景
- 问题2: 拖动没有边界 → 添加 coerceIn clamp

## Test plan
- [x] Build passes
- [ ] 打开 WebView 登录页，验证按钮在白色/深色页面都清晰可见
- [ ] 拖动按钮到屏幕边缘，验证不会飞出屏幕

🤖 Generated with [Claude Code](https://claude.com/claude-code)