### PR TITLE
fix: CodingPlan prefetch uses correct fields per provider

### DIFF
--- a/app/src/main/java/com/lockit/ui/screens/add_credential/AddCredentialScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/add_credential/AddCredentialScreen.kt
@@ -650,12 +650,26 @@ fun AddCredentialScreen(
                                     val baseUrl = getField(4).takeIf { it.isNotBlank() }
                                         ?: extractBaseUrlFromCurl(rawCurl)
 
-                                    // Save to SharedPreferences for immediate prefetch
-                                    com.lockit.data.vault.CodingPlanPrefs.save(
+                                    // Save to SharedPreferences for immediate prefetch with correct fields per provider
+                                    val prefsData: Map<String, String> = when (provider) {
+                                        "qwen", "qwen_bailian" -> mapOf(
+                                            "cookie" to cookie,
+                                            "api_key" to (apiKey ?: ""),
+                                        )
+                                        "openai", "chatgpt" -> mapOf(
+                                            "accessToken" to (apiKey ?: ""),
+                                            "accountId" to (authExtraData["accountId"] ?: ""),
+                                        ).filterValues { it.isNotBlank() }
+                                        "anthropic", "claude" -> mapOf(
+                                            "sessionKey" to (apiKey ?: ""),
+                                            "orgId" to (authExtraData["orgId"] ?: ""),
+                                        ).filterValues { it.isNotBlank() }
+                                        else -> mapOf("api_key" to (apiKey ?: ""))
+                                    }
+                                    com.lockit.data.vault.CodingPlanPrefs.saveProviderData(
                                         context = app,
                                         provider = provider,
-                                        cookie = cookie,
-                                        apiKey = apiKey ?: "",
+                                        data = prefsData,
                                     )
 
                                     // Build metadata based on provider type (include authExtraData)

--- a/app/src/main/java/com/lockit/ui/screens/add_credential/AddCredentialScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/add_credential/AddCredentialScreen.kt
@@ -651,6 +651,8 @@ fun AddCredentialScreen(
                                         ?: extractBaseUrlFromCurl(rawCurl)
 
                                     // Save to SharedPreferences for immediate prefetch with correct fields per provider
+                                    // Note: cookie field stores user's manual edits for accountId/orgId
+                                    // We prioritize manual edits over WebView-extracted data
                                     val prefsData: Map<String, String> = when (provider) {
                                         "qwen", "qwen_bailian" -> mapOf(
                                             "cookie" to cookie,
@@ -658,12 +660,12 @@ fun AddCredentialScreen(
                                         )
                                         "openai", "chatgpt" -> mapOf(
                                             "accessToken" to (apiKey ?: ""),
-                                            "accountId" to (authExtraData["accountId"] ?: ""),
-                                        ).filterValues { it.isNotBlank() }
+                                            "accountId" to (cookie.ifBlank { authExtraData["accountId"] ?: "" }),
+                                        )
                                         "anthropic", "claude" -> mapOf(
                                             "sessionKey" to (apiKey ?: ""),
-                                            "orgId" to (authExtraData["orgId"] ?: ""),
-                                        ).filterValues { it.isNotBlank() }
+                                            "orgId" to (cookie.ifBlank { authExtraData["orgId"] ?: "" }),
+                                        )
                                         else -> mapOf("api_key" to (apiKey ?: ""))
                                     }
                                     com.lockit.data.vault.CodingPlanPrefs.saveProviderData(


### PR DESCRIPTION
## Summary
- Fix CodingPlan prefetch for ChatGPT/Claude providers
- Auth data now stored with correct fields in CodingPlanPrefs
- Enables immediate prefetch on lock screen for all providers

## Root Cause
The user reported: "计划面板加载速度太慢了，没有在锁屏页面就异步获取"

Investigation revealed:
- MainActivity prefetch uses `CodingPlanPrefs` (SharedPreferences cache)
- ReposScreen fetches from vault credentials
- `CodingPlanPrefs.save()` was called for all providers with wrong fields
- ChatGPT needs `accessToken/accountId`, Claude needs `sessionKey/orgId`
- But `save()` only stored `cookie/api_key` (correct only for qwen_bailian)
- Prefetch returned empty/wrong data, causing slow load on ReposScreen

## Changes
- Use `saveProviderData()` instead of `save()` with provider-specific fields
- qwen_bailian: `{cookie, api_key}`
- chatgpt: `{accessToken, accountId}`
- claude: `{sessionKey, orgId}`

## Test plan
- [ ] Add ChatGPT credential via WebView auth
- [ ] Verify prefetch works on lock screen (no loading spinner on ReposScreen)
- [ ] Add Claude credential via WebView auth
- [ ] Verify prefetch works for Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)