### PR TITLE
feat: Team sharing MVP - Phase 1 core implementation

### DIFF
--- a/app/src/main/java/com/lockit/data/database/LockitDatabase.kt
+++ b/app/src/main/java/com/lockit/data/database/LockitDatabase.kt
@@ -4,15 +4,25 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import com.lockit.data.team.TeamDao
+import com.lockit.data.team.TeamEntity
+import com.lockit.data.team.TeamMemberEntity
+import com.lockit.data.team.SharedCredentialEntity
 
 @Database(
-    entities = [CredentialEntity::class],
-    version = 1,
+    entities = [
+        CredentialEntity::class,
+        TeamEntity::class,
+        TeamMemberEntity::class,
+        SharedCredentialEntity::class,
+    ],
+    version = 2,
     exportSchema = false
 )
 abstract class LockitDatabase : RoomDatabase() {
 
     abstract fun credentialDao(): CredentialDao
+    abstract fun teamDao(): TeamDao
 
     companion object {
         private const val DB_NAME = "lockit.db"
@@ -26,7 +36,9 @@ abstract class LockitDatabase : RoomDatabase() {
                     context.applicationContext,
                     LockitDatabase::class.java,
                     DB_NAME
-                ).build()
+                )
+                    .fallbackToDestructiveMigration()  // Allow version upgrade without migration
+                    .build()
                 INSTANCE = instance
                 instance
             }

--- a/app/src/main/java/com/lockit/data/database/LockitDatabase.kt
+++ b/app/src/main/java/com/lockit/data/database/LockitDatabase.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.lockit.data.team.TeamDao
 import com.lockit.data.team.TeamEntity
 import com.lockit.data.team.TeamMemberEntity
@@ -30,6 +32,51 @@ abstract class LockitDatabase : RoomDatabase() {
         @Volatile
         private var INSTANCE: LockitDatabase? = null
 
+        // Migration from v1 to v2: add team tables
+        private val MIGRATION_1_2 = Migration(1, 2) { db ->
+            // Create teams table
+            db.execSQL("""
+                CREATE TABLE IF NOT EXISTS teams (
+                    id TEXT PRIMARY KEY NOT NULL,
+                    name TEXT NOT NULL,
+                    teamKeyEncoded TEXT NOT NULL,
+                    inviteCode TEXT NOT NULL,
+                    createdAt INTEGER NOT NULL,
+                    createdBy TEXT NOT NULL,
+                    myMemberId TEXT NOT NULL,
+                    myRole TEXT NOT NULL
+                )
+            """)
+            // Create team_members table
+            db.execSQL("""
+                CREATE TABLE IF NOT EXISTS team_members (
+                    id TEXT PRIMARY KEY NOT NULL,
+                    teamId TEXT NOT NULL,
+                    name TEXT NOT NULL,
+                    role TEXT NOT NULL,
+                    joinedAt INTEGER NOT NULL,
+                    FOREIGN KEY (teamId) REFERENCES teams(id) ON DELETE CASCADE
+                )
+            """)
+            db.execSQL("CREATE INDEX IF NOT EXISTS index_team_members_teamId ON team_members(teamId)")
+            // Create shared_credentials table
+            db.execSQL("""
+                CREATE TABLE IF NOT EXISTS shared_credentials (
+                    id TEXT PRIMARY KEY NOT NULL,
+                    credentialId TEXT NOT NULL,
+                    teamId TEXT NOT NULL,
+                    encryptedValue BLOB NOT NULL,
+                    createdBy TEXT NOT NULL,
+                    createdAt INTEGER NOT NULL,
+                    lastModifiedBy TEXT NOT NULL,
+                    lastModifiedAt INTEGER NOT NULL,
+                    FOREIGN KEY (teamId) REFERENCES teams(id) ON DELETE CASCADE
+                )
+            """)
+            db.execSQL("CREATE INDEX IF NOT EXISTS index_shared_credentials_teamId ON shared_credentials(teamId)")
+            db.execSQL("CREATE INDEX IF NOT EXISTS index_shared_credentials_credentialId ON shared_credentials(credentialId)")
+        }
+
         fun getInstance(context: Context): LockitDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -37,7 +84,7 @@ abstract class LockitDatabase : RoomDatabase() {
                     LockitDatabase::class.java,
                     DB_NAME
                 )
-                    .fallbackToDestructiveMigration()  // Allow version upgrade without migration
+                    .addMigrations(MIGRATION_1_2)
                     .build()
                 INSTANCE = instance
                 instance

--- a/app/src/main/java/com/lockit/data/team/Team.kt
+++ b/app/src/main/java/com/lockit/data/team/Team.kt
@@ -1,0 +1,71 @@
+package com.lockit.data.team
+
+import java.time.Instant
+
+/**
+ * Team member role.
+ */
+enum class TeamRole {
+    ADMIN,      // Can manage team + edit credentials
+    MEMBER,     // Can edit shared credentials
+    VIEWER,     // Can only view shared credentials
+}
+
+/**
+ * Team member.
+ */
+data class TeamMember(
+    val id: String,          // UUID
+    val name: String,        // Display name (device name or user name)
+    val role: TeamRole,
+    val joinedAt: Instant,
+)
+
+/**
+ * Team - a group sharing credentials.
+ */
+data class Team(
+    val id: String,          // UUID
+    val name: String,        // Team name
+    val teamKey: ByteArray,  // AES-256 shared key
+    val inviteCode: String,  // For new members to join
+    val members: List<TeamMember>,
+    val createdAt: Instant,
+    val createdBy: String,   // Member ID of creator
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Team) return false
+        return id == other.id
+    }
+
+    override fun hashCode(): Int = id.hashCode()
+
+    /**
+     * Check if user is admin of this team.
+     */
+    fun isAdmin(memberId: String): Boolean {
+        return members.find { it.id == memberId }?.role == TeamRole.ADMIN
+    }
+
+    /**
+     * Encode team invite for sharing (QR code or link).
+     */
+    fun encodeInvite(): String {
+        return TeamCrypto.encodeTeamInvite(teamKey, inviteCode)
+    }
+}
+
+/**
+ * Shared credential reference (stored in team database).
+ */
+data class SharedCredential(
+    val id: String,               // UUID
+    val credentialId: String,     // Original credential ID
+    val teamId: String,           // Team ID
+    val encryptedValue: ByteArray, // Encrypted with team key
+    val createdBy: String,        // Member ID
+    val createdAt: Instant,
+    val lastModifiedBy: String,
+    val lastModifiedAt: Instant,
+)

--- a/app/src/main/java/com/lockit/data/team/TeamCrypto.kt
+++ b/app/src/main/java/com/lockit/data/team/TeamCrypto.kt
@@ -1,0 +1,97 @@
+package com.lockit.data.team
+
+import java.security.SecureRandom
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+import java.util.Base64
+
+/**
+ * Team crypto operations for shared credentials.
+ * Uses AES-256-GCM with team-shared key (independent of device PIN).
+ */
+object TeamCrypto {
+    private const val NONCE_LENGTH = 12
+    private const val GCM_TAG_LENGTH = 128
+    private const val KEY_LENGTH = 32  // 256 bits
+    private const val INVITE_CODE_LENGTH = 16  // bytes for random invite code
+
+    private val secureRandom = SecureRandom()
+
+    /**
+     * Generate a new AES-256 team key.
+     */
+    fun generateTeamKey(): ByteArray {
+        val key = ByteArray(KEY_LENGTH)
+        secureRandom.nextBytes(key)
+        return key
+    }
+
+    /**
+     * Generate a random invite code (for joining team).
+     * Returns Base64-encoded string for easy sharing.
+     */
+    fun generateInviteCode(): String {
+        val code = ByteArray(INVITE_CODE_LENGTH)
+        secureRandom.nextBytes(code)
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(code)
+    }
+
+    /**
+     * Encode team key + invite code into a shareable string.
+     * Format: base64(teamKey) + ":" + inviteCode
+     */
+    fun encodeTeamInvite(teamKey: ByteArray, inviteCode: String): String {
+        val keyBase64 = Base64.getUrlEncoder().withoutPadding().encodeToString(teamKey)
+        return "$keyBase64:$inviteCode"
+    }
+
+    /**
+     * Decode team invite string back to key + code.
+     */
+    fun decodeTeamInvite(inviteString: String): Pair<ByteArray, String>? {
+        val parts = inviteString.split(":")
+        if (parts.size != 2) return null
+        return try {
+            val key = Base64.getUrlDecoder().decode(parts[0])
+            val code = parts[1]
+            if (key.size != KEY_LENGTH) null else Pair(key, code)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /**
+     * Encrypt shared credential value with team key.
+     * Format: [12-byte nonce][ciphertext + 16-byte GCM tag]
+     */
+    fun encrypt(plaintext: ByteArray, teamKey: ByteArray): ByteArray {
+        val nonce = ByteArray(NONCE_LENGTH)
+        secureRandom.nextBytes(nonce)
+
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        val keySpec = SecretKeySpec(teamKey, "AES")
+        val gcmSpec = GCMParameterSpec(GCM_TAG_LENGTH, nonce)
+        cipher.init(Cipher.ENCRYPT_MODE, keySpec, gcmSpec)
+
+        val ciphertext = cipher.doFinal(plaintext)
+        return nonce + ciphertext
+    }
+
+    /**
+     * Decrypt shared credential value with team key.
+     */
+    fun decrypt(data: ByteArray, teamKey: ByteArray): ByteArray {
+        require(data.size > NONCE_LENGTH) { "Data too short: ${data.size} bytes" }
+
+        val nonce = data.copyOfRange(0, NONCE_LENGTH)
+        val ciphertext = data.copyOfRange(NONCE_LENGTH, data.size)
+
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        val keySpec = SecretKeySpec(teamKey, "AES")
+        val gcmSpec = GCMParameterSpec(GCM_TAG_LENGTH, nonce)
+        cipher.init(Cipher.DECRYPT_MODE, keySpec, gcmSpec)
+
+        return cipher.doFinal(ciphertext)
+    }
+}

--- a/app/src/main/java/com/lockit/data/team/TeamCrypto.kt
+++ b/app/src/main/java/com/lockit/data/team/TeamCrypto.kt
@@ -1,10 +1,10 @@
 package com.lockit.data.team
 
+import android.util.Base64
 import java.security.SecureRandom
 import javax.crypto.Cipher
 import javax.crypto.spec.GCMParameterSpec
 import javax.crypto.spec.SecretKeySpec
-import java.util.Base64
 
 /**
  * Team crypto operations for shared credentials.
@@ -34,7 +34,7 @@ object TeamCrypto {
     fun generateInviteCode(): String {
         val code = ByteArray(INVITE_CODE_LENGTH)
         secureRandom.nextBytes(code)
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(code)
+        return Base64.encodeToString(code, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
     }
 
     /**
@@ -42,7 +42,7 @@ object TeamCrypto {
      * Format: base64(teamKey) + ":" + inviteCode
      */
     fun encodeTeamInvite(teamKey: ByteArray, inviteCode: String): String {
-        val keyBase64 = Base64.getUrlEncoder().withoutPadding().encodeToString(teamKey)
+        val keyBase64 = Base64.encodeToString(teamKey, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
         return "$keyBase64:$inviteCode"
     }
 
@@ -53,7 +53,7 @@ object TeamCrypto {
         val parts = inviteString.split(":")
         if (parts.size != 2) return null
         return try {
-            val key = Base64.getUrlDecoder().decode(parts[0])
+            val key = Base64.decode(parts[0], Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
             val code = parts[1]
             if (key.size != KEY_LENGTH) null else Pair(key, code)
         } catch (e: Exception) {

--- a/app/src/main/java/com/lockit/data/team/TeamDao.kt
+++ b/app/src/main/java/com/lockit/data/team/TeamDao.kt
@@ -1,0 +1,81 @@
+package com.lockit.data.team
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Delete
+import androidx.room.Transaction
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Data access for teams and shared credentials.
+ */
+@Dao
+interface TeamDao {
+
+    // === Teams ===
+
+    @Query("SELECT * FROM teams ORDER BY createdAt DESC")
+    fun getAllTeams(): Flow<List<TeamEntity>>
+
+    @Query("SELECT * FROM teams WHERE id = :teamId")
+    suspend fun getTeamById(teamId: String): TeamEntity?
+
+    @Query("SELECT COUNT(*) FROM teams")
+    suspend fun getTeamCount(): Int
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertTeam(team: TeamEntity)
+
+    @Delete
+    suspend fun deleteTeam(team: TeamEntity)
+
+    @Query("DELETE FROM teams WHERE id = :teamId")
+    suspend fun deleteTeamById(teamId: String)
+
+    // === Members ===
+
+    @Query("SELECT * FROM team_members WHERE teamId = :teamId ORDER BY joinedAt ASC")
+    suspend fun getMembers(teamId: String): List<TeamMemberEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertMember(member: TeamMemberEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertMembers(members: List<TeamMemberEntity>)
+
+    @Query("DELETE FROM team_members WHERE teamId = :teamId AND id = :memberId")
+    suspend fun deleteMember(teamId: String, memberId: String)
+
+    @Query("DELETE FROM team_members WHERE teamId = :teamId")
+    suspend fun clearMembers(teamId: String)
+
+    // === Shared Credentials ===
+
+    @Query("SELECT * FROM shared_credentials WHERE teamId = :teamId ORDER BY createdAt DESC")
+    fun getSharedCredentials(teamId: String): Flow<List<SharedCredentialEntity>>
+
+    @Query("SELECT * FROM shared_credentials WHERE id = :id")
+    suspend fun getSharedCredentialById(id: String): SharedCredentialEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertSharedCredential(cred: SharedCredentialEntity)
+
+    @Delete
+    suspend fun deleteSharedCredential(cred: SharedCredentialEntity)
+
+    @Query("DELETE FROM shared_credentials WHERE teamId = :teamId AND credentialId = :credentialId")
+    suspend fun deleteSharedCredentialByOriginalId(teamId: String, credentialId: String)
+
+    @Query("DELETE FROM shared_credentials WHERE teamId = :teamId")
+    suspend fun deleteAllSharedCredentials(teamId: String)
+
+    // === Clear all team data ===
+
+    @Transaction
+    suspend fun clearAllTeamData(teamId: String) {
+        deleteAllSharedCredentials(teamId)
+        deleteTeamById(teamId)
+    }
+}

--- a/app/src/main/java/com/lockit/data/team/TeamDao.kt
+++ b/app/src/main/java/com/lockit/data/team/TeamDao.kt
@@ -76,6 +76,7 @@ interface TeamDao {
     @Transaction
     suspend fun clearAllTeamData(teamId: String) {
         deleteAllSharedCredentials(teamId)
+        clearMembers(teamId)
         deleteTeamById(teamId)
     }
 }

--- a/app/src/main/java/com/lockit/data/team/TeamDao.kt
+++ b/app/src/main/java/com/lockit/data/team/TeamDao.kt
@@ -25,7 +25,7 @@ interface TeamDao {
     @Query("SELECT COUNT(*) FROM teams")
     suspend fun getTeamCount(): Int
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Insert(onConflict = OnConflictStrategy.ABORT)
     suspend fun insertTeam(team: TeamEntity)
 
     @Delete
@@ -39,10 +39,10 @@ interface TeamDao {
     @Query("SELECT * FROM team_members WHERE teamId = :teamId ORDER BY joinedAt ASC")
     suspend fun getMembers(teamId: String): List<TeamMemberEntity>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Insert(onConflict = OnConflictStrategy.ABORT)
     suspend fun insertMember(member: TeamMemberEntity)
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Insert(onConflict = OnConflictStrategy.ABORT)
     suspend fun insertMembers(members: List<TeamMemberEntity>)
 
     @Query("DELETE FROM team_members WHERE teamId = :teamId AND id = :memberId")
@@ -78,5 +78,13 @@ interface TeamDao {
         deleteAllSharedCredentials(teamId)
         clearMembers(teamId)
         deleteTeamById(teamId)
+    }
+
+    // === Transaction wrappers for atomic operations ===
+
+    @Transaction
+    suspend fun insertTeamWithMember(team: TeamEntity, member: TeamMemberEntity) {
+        insertTeam(team)
+        insertMember(member)
     }
 }

--- a/app/src/main/java/com/lockit/data/team/TeamEntity.kt
+++ b/app/src/main/java/com/lockit/data/team/TeamEntity.kt
@@ -1,5 +1,6 @@
 package com.lockit.data.team
 
+import android.util.Base64
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import androidx.room.ForeignKey
@@ -22,8 +23,8 @@ data class TeamEntity(
     val myRole: String,          // ADMIN, MEMBER, VIEWER
 ) {
     fun toTeam(): Team {
-        val teamKey = java.util.Base64.getUrlDecoder().decode(teamKeyEncoded)
-        val role = TeamRole.valueOf(myRole)
+        val teamKey = Base64.decode(teamKeyEncoded, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
+        val role = try { TeamRole.valueOf(myRole) } catch (_: Exception) { TeamRole.MEMBER }
         val member = TeamMember(
             id = myMemberId,
             name = android.os.Build.MODEL,
@@ -43,9 +44,10 @@ data class TeamEntity(
 
     companion object {
         fun fromTeam(team: Team, myMemberId: String): TeamEntity {
-            val keyEncoded = java.util.Base64.getUrlEncoder()
-                .withoutPadding()
-                .encodeToString(team.teamKey)
+            val keyEncoded = Base64.encodeToString(
+                team.teamKey,
+                Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP
+            )
             val myMember = team.members.find { it.id == myMemberId }
             return TeamEntity(
                 id = team.id,

--- a/app/src/main/java/com/lockit/data/team/TeamEntity.kt
+++ b/app/src/main/java/com/lockit/data/team/TeamEntity.kt
@@ -1,0 +1,113 @@
+package com.lockit.data.team
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import androidx.room.ForeignKey
+import androidx.room.Index
+import java.time.Instant
+
+/**
+ * Room entity for Team.
+ */
+@Entity(tableName = "teams")
+data class TeamEntity(
+    @PrimaryKey
+    val id: String,              // UUID
+    val name: String,            // Team name
+    val teamKeyEncoded: String,  // Base64 encoded AES-256 key
+    val inviteCode: String,      // Invite code for joining
+    val createdAt: Long,         // Epoch millis
+    val createdBy: String,       // Creator device/member ID
+    val myMemberId: String,      // This device's member ID in the team
+    val myRole: String,          // ADMIN, MEMBER, VIEWER
+) {
+    fun toTeam(): Team {
+        val teamKey = java.util.Base64.getUrlDecoder().decode(teamKeyEncoded)
+        val role = TeamRole.valueOf(myRole)
+        val member = TeamMember(
+            id = myMemberId,
+            name = android.os.Build.MODEL,
+            role = role,
+            joinedAt = Instant.ofEpochMilli(createdAt),
+        )
+        return Team(
+            id = id,
+            name = name,
+            teamKey = teamKey,
+            inviteCode = inviteCode,
+            members = listOf(member),  // Only local member stored
+            createdAt = Instant.ofEpochMilli(createdAt),
+            createdBy = createdBy,
+        )
+    }
+
+    companion object {
+        fun fromTeam(team: Team, myMemberId: String): TeamEntity {
+            val keyEncoded = java.util.Base64.getUrlEncoder()
+                .withoutPadding()
+                .encodeToString(team.teamKey)
+            val myMember = team.members.find { it.id == myMemberId }
+            return TeamEntity(
+                id = team.id,
+                name = team.name,
+                teamKeyEncoded = keyEncoded,
+                inviteCode = team.inviteCode,
+                createdAt = team.createdAt.toEpochMilli(),
+                createdBy = team.createdBy,
+                myMemberId = myMemberId,
+                myRole = myMember?.role?.name ?: TeamRole.MEMBER.name,
+            )
+        }
+    }
+}
+
+/**
+ * Room entity for member list (stored separately for sync).
+ */
+@Entity(
+    tableName = "team_members",
+    foreignKeys = [
+        ForeignKey(
+            entity = TeamEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["teamId"],
+            onDelete = ForeignKey.CASCADE,
+        )
+    ],
+    indices = [Index("teamId")]
+)
+data class TeamMemberEntity(
+    @PrimaryKey
+    val id: String,              // Member UUID
+    val teamId: String,          // Team ID
+    val name: String,            // Display name
+    val role: String,            // ADMIN, MEMBER, VIEWER
+    val joinedAt: Long,          // Epoch millis
+)
+
+/**
+ * Room entity for shared credential reference.
+ */
+@Entity(
+    tableName = "shared_credentials",
+    foreignKeys = [
+        ForeignKey(
+            entity = TeamEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["teamId"],
+            onDelete = ForeignKey.CASCADE,
+        )
+    ],
+    indices = [Index("teamId"), Index("credentialId")]
+)
+data class SharedCredentialEntity(
+    @PrimaryKey
+    val id: String,              // UUID
+    val credentialId: String,    // Original credential ID (for reference)
+    val teamId: String,          // Team ID
+    val encryptedValue: ByteArray, // Encrypted with team key
+    val createdBy: String,       // Member ID who shared
+    val createdAt: Long,         // Epoch millis
+    val lastModifiedBy: String,
+    val lastModifiedAt: Long,
+)

--- a/app/src/main/java/com/lockit/data/team/TeamManager.kt
+++ b/app/src/main/java/com/lockit/data/team/TeamManager.kt
@@ -52,11 +52,8 @@ class TeamManager(
                 createdBy = memberId,
             )
 
-            // Store in database
+            // Store in database atomically
             val entity = TeamEntity.fromTeam(team, memberId)
-            teamDao.insertTeam(entity)
-
-            // Persist the local member into team_members table
             val memberEntity = TeamMemberEntity(
                 id = memberId,
                 teamId = teamId,
@@ -64,7 +61,7 @@ class TeamManager(
                 role = TeamRole.ADMIN.name,
                 joinedAt = now.toEpochMilli()
             )
-            teamDao.insertMember(memberEntity)
+            teamDao.insertTeamWithMember(entity, memberEntity)
 
             // Audit log
             auditLogger.logTeamCreated(teamId, name)
@@ -117,9 +114,6 @@ class TeamManager(
             )
 
             val entity = TeamEntity.fromTeam(team, memberId)
-            teamDao.insertTeam(entity)
-
-            // Persist the local member into team_members table
             val memberEntity = TeamMemberEntity(
                 id = memberId,
                 teamId = teamId,
@@ -127,7 +121,7 @@ class TeamManager(
                 role = TeamRole.MEMBER.name,
                 joinedAt = now.toEpochMilli()
             )
-            teamDao.insertMember(memberEntity)
+            teamDao.insertTeamWithMember(entity, memberEntity)
 
             auditLogger.logTeamJoined(teamId)
 

--- a/app/src/main/java/com/lockit/data/team/TeamManager.kt
+++ b/app/src/main/java/com/lockit/data/team/TeamManager.kt
@@ -23,14 +23,16 @@ class TeamManager(
     /**
      * Create a new team.
      * Generates team key, invite code, and adds this device as admin.
+     * Team ID is derived from inviteCode for consistent joining.
      * @return The created team with invite string for sharing.
      */
     suspend fun createTeam(name: String): Result<Team> = withContext(Dispatchers.IO) {
         try {
-            val teamId = UUID.randomUUID().toString()
-            val memberId = "${android.os.Build.MODEL}-${UUID.randomUUID().toString().take(8)}"
             val teamKey = TeamCrypto.generateTeamKey()
             val inviteCode = TeamCrypto.generateInviteCode()
+            // Team ID derived from inviteCode for consistent joining across devices
+            val teamId = UUID.nameUUIDFromBytes(inviteCode.toByteArray(Charsets.UTF_8)).toString()
+            val memberId = "${android.os.Build.MODEL}-${UUID.randomUUID().toString().take(8)}"
             val now = Instant.now()
 
             val team = Team(
@@ -79,7 +81,7 @@ class TeamManager(
             val now = Instant.now()
 
             // Generate a team ID from invite code hash (all members use same ID)
-            val teamId = UUID.nameUUIDFromBytes(inviteCode.toByteArray()).toString()
+            val teamId = UUID.nameUUIDFromBytes(inviteCode.toByteArray(Charsets.UTF_8)).toString()
 
             // Check if already joined this team
             val existing = teamDao.getTeamById(teamId)

--- a/app/src/main/java/com/lockit/data/team/TeamManager.kt
+++ b/app/src/main/java/com/lockit/data/team/TeamManager.kt
@@ -56,6 +56,16 @@ class TeamManager(
             val entity = TeamEntity.fromTeam(team, memberId)
             teamDao.insertTeam(entity)
 
+            // Persist the local member into team_members table
+            val memberEntity = TeamMemberEntity(
+                id = memberId,
+                teamId = teamId,
+                name = android.os.Build.MODEL,
+                role = TeamRole.ADMIN.name,
+                joinedAt = now.toEpochMilli()
+            )
+            teamDao.insertMember(memberEntity)
+
             // Audit log
             auditLogger.logTeamCreated(teamId, name)
 
@@ -108,6 +118,16 @@ class TeamManager(
 
             val entity = TeamEntity.fromTeam(team, memberId)
             teamDao.insertTeam(entity)
+
+            // Persist the local member into team_members table
+            val memberEntity = TeamMemberEntity(
+                id = memberId,
+                teamId = teamId,
+                name = android.os.Build.MODEL,
+                role = TeamRole.MEMBER.name,
+                joinedAt = now.toEpochMilli()
+            )
+            teamDao.insertMember(memberEntity)
 
             auditLogger.logTeamJoined(teamId)
 

--- a/app/src/main/java/com/lockit/data/team/TeamManager.kt
+++ b/app/src/main/java/com/lockit/data/team/TeamManager.kt
@@ -137,10 +137,20 @@ class TeamManager(
     fun getAllTeams() = teamDao.getAllTeams()
 
     /**
-     * Get a specific team by ID.
+     * Get a specific team by ID with full member list.
      */
     suspend fun getTeamById(teamId: String): Team? = withContext(Dispatchers.IO) {
-        teamDao.getTeamById(teamId)?.toTeam()
+        val entity = teamDao.getTeamById(teamId) ?: return@withContext null
+        val memberEntities = teamDao.getMembers(teamId)
+        val members = memberEntities.map { m ->
+            TeamMember(
+                id = m.id,
+                name = m.name,
+                role = try { TeamRole.valueOf(m.role) } catch (_: Exception) { TeamRole.MEMBER },
+                joinedAt = Instant.ofEpochMilli(m.joinedAt)
+            )
+        }
+        entity.toTeam().copy(members = members)
     }
 
     /**

--- a/app/src/main/java/com/lockit/data/team/TeamManager.kt
+++ b/app/src/main/java/com/lockit/data/team/TeamManager.kt
@@ -1,0 +1,178 @@
+package com.lockit.data.team
+
+import android.content.Context
+import com.lockit.data.audit.AuditLogger
+import com.lockit.data.database.LockitDatabase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Manages team operations: create, join, invite.
+ */
+class TeamManager(
+    private val context: Context,
+    private val auditLogger: AuditLogger,
+) {
+
+    private val teamDao: TeamDao by lazy {
+        LockitDatabase.getInstance(context).teamDao()
+    }
+
+    /**
+     * Create a new team.
+     * Generates team key, invite code, and adds this device as admin.
+     * @return The created team with invite string for sharing.
+     */
+    suspend fun createTeam(name: String): Result<Team> = withContext(Dispatchers.IO) {
+        try {
+            val teamId = UUID.randomUUID().toString()
+            val memberId = "${android.os.Build.MODEL}-${UUID.randomUUID().toString().take(8)}"
+            val teamKey = TeamCrypto.generateTeamKey()
+            val inviteCode = TeamCrypto.generateInviteCode()
+            val now = Instant.now()
+
+            val team = Team(
+                id = teamId,
+                name = name,
+                teamKey = teamKey,
+                inviteCode = inviteCode,
+                members = listOf(
+                    TeamMember(
+                        id = memberId,
+                        name = android.os.Build.MODEL,
+                        role = TeamRole.ADMIN,
+                        joinedAt = now,
+                    )
+                ),
+                createdAt = now,
+                createdBy = memberId,
+            )
+
+            // Store in database
+            val entity = TeamEntity.fromTeam(team, memberId)
+            teamDao.insertTeam(entity)
+
+            // Audit log
+            auditLogger.logTeamCreated(teamId, name)
+
+            Result.success(team)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Join a team using invite string.
+     * Invite string format: base64(teamKey):inviteCode
+     */
+    suspend fun joinTeam(inviteString: String): Result<Team> = withContext(Dispatchers.IO) {
+        try {
+            val decoded = TeamCrypto.decodeTeamInvite(inviteString)
+            if (decoded == null) {
+                return@withContext Result.failure(IllegalArgumentException("Invalid invite string"))
+            }
+
+            val (teamKey, inviteCode) = decoded
+            val memberId = "${android.os.Build.MODEL}-${UUID.randomUUID().toString().take(8)}"
+            val now = Instant.now()
+
+            // Generate a team ID from invite code hash (all members use same ID)
+            val teamId = UUID.nameUUIDFromBytes(inviteCode.toByteArray()).toString()
+
+            // Check if already joined this team
+            val existing = teamDao.getTeamById(teamId)
+            if (existing != null) {
+                return@withContext Result.failure(IllegalStateException("Already a member of this team"))
+            }
+
+            val team = Team(
+                id = teamId,
+                name = "Team",  // Name can be updated later
+                teamKey = teamKey,
+                inviteCode = inviteCode,
+                members = listOf(
+                    TeamMember(
+                        id = memberId,
+                        name = android.os.Build.MODEL,
+                        role = TeamRole.MEMBER,  // New joiners are members
+                        joinedAt = now,
+                    )
+                ),
+                createdAt = now,
+                createdBy = memberId,  // Will be updated when syncing with team admin
+            )
+
+            val entity = TeamEntity.fromTeam(team, memberId)
+            teamDao.insertTeam(entity)
+
+            auditLogger.logTeamJoined(teamId)
+
+            Result.success(team)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Get all teams this device belongs to.
+     */
+    fun getAllTeams() = teamDao.getAllTeams()
+
+    /**
+     * Get a specific team by ID.
+     */
+    suspend fun getTeamById(teamId: String): Team? = withContext(Dispatchers.IO) {
+        teamDao.getTeamById(teamId)?.toTeam()
+    }
+
+    /**
+     * Leave a team (delete local membership).
+     */
+    suspend fun leaveTeam(teamId: String): Result<Unit> = withContext(Dispatchers.IO) {
+        try {
+            teamDao.clearAllTeamData(teamId)
+            auditLogger.logTeamLeft(teamId)
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Generate QR code content for team invite.
+     * Format: lockit-team://join?invite=<encodedInvite>
+     */
+    fun generateInviteQrContent(team: Team): String {
+        val encodedInvite = team.encodeInvite()
+        return "lockit-team://join?invite=$encodedInvite"
+    }
+
+    /**
+     * Parse QR code content to get invite string.
+     */
+    fun parseInviteQrContent(qrContent: String): String? {
+        val prefix = "lockit-team://join?invite="
+        return if (qrContent.startsWith(prefix)) {
+            qrContent.removePrefix(prefix)
+        } else {
+            null
+        }
+    }
+}
+
+/**
+ * Audit action names for team operations.
+ */
+fun AuditLogger.logTeamCreated(teamId: String, teamName: String) {
+    log("TEAM_CREATED", "teamId=$teamId teamName=$teamName")
+}
+
+fun AuditLogger.logTeamJoined(teamId: String) {
+    log("TEAM_JOINED", "teamId=$teamId")
+}
+
+fun AuditLogger.logTeamLeft(teamId: String) {
+    log("TEAM_LEFT", "teamId=$teamId")
+}

--- a/app/src/main/java/com/lockit/ui/screens/logs/LogsScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/logs/LogsScreen.kt
@@ -262,6 +262,9 @@ private fun LogRow(entry: AuditEntry) {
         "CREDENTIAL_DELETED" -> stringResource(R.string.action_credential_deleted)
         "CREDENTIAL_VIEWED" -> stringResource(R.string.action_credential_viewed)
         "CREDENTIAL_COPIED" -> stringResource(R.string.action_credential_copied)
+        "TEAM_CREATED" -> stringResource(R.string.action_team_created)
+        "TEAM_JOINED" -> stringResource(R.string.action_team_joined)
+        "TEAM_LEFT" -> stringResource(R.string.action_team_left)
         else -> entry.action
     }
 

--- a/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
@@ -326,10 +326,8 @@ fun ReposScreen(
             while (CodingPlanPrefetchState.isLoading) {
                 kotlinx.coroutines.delay(100)
             }
-            // Update ViewModel with prefetch result
-            CodingPlanPrefetchState.quota?.let {
-                viewModel.updateQuotaFromPrefetch(it, CodingPlanPrefetchState.error)
-            }
+            // Update ViewModel with prefetch result (always call to clear loading state)
+            viewModel.updateQuotaFromPrefetch(CodingPlanPrefetchState.quota, CodingPlanPrefetchState.error)
         }
     }
 

--- a/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
@@ -138,7 +138,7 @@ class ReposViewModel(app: LockitApp) : ViewModel() {
     private val _selectedProvider = MutableStateFlow<String>("qwen_bailian")
     val selectedProvider: StateFlow<String> = _selectedProvider.asStateFlow()
 
-    private var hasAutoFetchedQuota = false
+    var hasAutoFetchedQuota = false  // Public for LaunchedEffect observation
     private var currentApp: LockitApp? = null
 
     init {
@@ -220,21 +220,36 @@ class ReposViewModel(app: LockitApp) : ViewModel() {
 
     // Auto-fetch when credentials become available (call from UI once)
     fun autoFetchIfNeeded() {
-        // First check if we have prefetched quota from app startup
-        if (!hasAutoFetchedQuota) {
-            val prefetched = CodingPlanPrefetchState.quota
-            if (prefetched != null) {
-                _codingPlanQuota.value = prefetched
-                _codingPlanQuotaError.value = CodingPlanPrefetchState.error
-                _isQuotaLoading.value = CodingPlanPrefetchState.isLoading
-                hasAutoFetchedQuota = true
-                return
-            }
+        if (hasAutoFetchedQuota) return
+
+        // Check if prefetch is still running - wait for it to complete
+        if (CodingPlanPrefetchState.isLoading) {
+            _isQuotaLoading.value = true
+            hasAutoFetchedQuota = true  // Mark as handled to prevent duplicate fetch
+            return
         }
-        // If no prefetched data, fetch from credentials
-        if (!hasAutoFetchedQuota && _credentials.value.any { it.type == CredentialType.CodingPlan }) {
+
+        // First check if we have prefetched quota from app startup
+        val prefetched = CodingPlanPrefetchState.quota
+        if (prefetched != null) {
+            _codingPlanQuota.value = prefetched
+            _codingPlanQuotaError.value = CodingPlanPrefetchState.error
+            _isQuotaLoading.value = false
+            hasAutoFetchedQuota = true
+            return
+        }
+
+        // If no prefetched data and not loading, fetch from credentials
+        if (_credentials.value.any { it.type == CredentialType.CodingPlan }) {
             fetchCodingPlanQuota(force = true)
         }
+    }
+
+    // Update quota when prefetch completes (called from LaunchedEffect observer)
+    fun updateQuotaFromPrefetch(quota: CodingPlanQuota?, error: String?) {
+        _codingPlanQuota.value = quota
+        _codingPlanQuotaError.value = error
+        _isQuotaLoading.value = false
     }
 }
 
@@ -302,6 +317,20 @@ fun ReposScreen(
     // Auto-fetch once when credentials become available
     LaunchedEffect(credentialList) {
         viewModel.autoFetchIfNeeded()
+    }
+
+    // Poll prefetch state until loading completes (handles race condition)
+    LaunchedEffect(CodingPlanPrefetchState.isLoading) {
+        if (CodingPlanPrefetchState.isLoading && viewModel.hasAutoFetchedQuota) {
+            // Wait for prefetch to complete
+            while (CodingPlanPrefetchState.isLoading) {
+                kotlinx.coroutines.delay(100)
+            }
+            // Update ViewModel with prefetch result
+            CodingPlanPrefetchState.quota?.let {
+                viewModel.updateQuotaFromPrefetch(it, CodingPlanPrefetchState.error)
+            }
+        }
     }
 
     val displayedServiceCredentials = remember(serviceCredentials, searchQuery, selectedService) {

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -320,6 +320,9 @@
     <string name="action_credential_deleted">凭据已删除</string>
     <string name="action_credential_viewed">凭据已查看</string>
     <string name="action_credential_copied">凭据已复制</string>
+    <string name="action_team_created">团队已创建</string>
+    <string name="action_team_joined">已加入团队</string>
+    <string name="action_team_left">已离开团队</string>
 
     <!-- Quota Gauge Labels -->
     <string name="quota_5h">5小时</string>
@@ -357,4 +360,30 @@
 
     <!-- Widget -->
     <string name="widget_coding_plan_description">显示 Coding Plan 用量进度条，实时查看配额</string>
+
+    <!-- Team Sharing -->
+    <string name="team_title">团队共享</string>
+    <string name="team_create_title">创建团队</string>
+    <string name="team_join_title">加入团队</string>
+    <string name="team_name_label">团队名称</string>
+    <string name="team_name_placeholder">输入团队名称</string>
+    <string name="team_create_btn">创建</string>
+    <string name="team_join_btn">加入团队</string>
+    <string name="team_invite_label">邀请码</string>
+    <string name="team_invite_placeholder">粘贴邀请码或扫描二维码</string>
+    <string name="team_invite_qr">扫描二维码</string>
+    <string name="team_invite_copy">复制邀请</string>
+    <string name="team_leave_btn">离开团队</string>
+    <string name="team_no_teams">暂无团队</string>
+    <string name="team_members">成员</string>
+    <string name="team_role_admin">管理员</string>
+    <string name="team_role_member">成员</string>
+    <string name="team_role_viewer">观察者</string>
+    <string name="team_created_success">团队已创建</string>
+    <string name="team_joined_success">已加入团队</string>
+    <string name="team_leave_success">已离开团队</string>
+    <string name="team_invite_invalid">邀请码无效</string>
+    <string name="team_already_member">已是团队成员</string>
+    <string name="team_invite_share_title">分享团队邀请</string>
+    <string name="team_invite_share_desc">让对方扫描二维码或复制邀请码加入团队</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -320,6 +320,9 @@
     <string name="action_credential_deleted">CREDENTIAL_DELETED</string>
     <string name="action_credential_viewed">CREDENTIAL_VIEWED</string>
     <string name="action_credential_copied">CREDENTIAL_COPIED</string>
+    <string name="action_team_created">TEAM_CREATED</string>
+    <string name="action_team_joined">TEAM_JOINED</string>
+    <string name="action_team_left">TEAM_LEFT</string>
 
     <!-- Quota Gauge Labels -->
     <string name="quota_5h">5H</string>
@@ -356,4 +359,30 @@
 
     <!-- Widget -->
     <string name="widget_coding_plan_description">显示 Coding Plan 用量进度条，实时查看配额</string>
+
+    <!-- Team Sharing -->
+    <string name="team_title">Team Sharing</string>
+    <string name="team_create_title">Create Team</string>
+    <string name="team_join_title">Join Team</string>
+    <string name="team_name_label">Team Name</string>
+    <string name="team_name_placeholder">Enter team name</string>
+    <string name="team_create_btn">Create</string>
+    <string name="team_join_btn">Join Team</string>
+    <string name="team_invite_label">Invite Code</string>
+    <string name="team_invite_placeholder">Paste invite code or scan QR</string>
+    <string name="team_invite_qr">Scan QR Code</string>
+    <string name="team_invite_copy">Copy Invite</string>
+    <string name="team_leave_btn">Leave Team</string>
+    <string name="team_no_teams">No teams</string>
+    <string name="team_members">Members</string>
+    <string name="team_role_admin">Admin</string>
+    <string name="team_role_member">Member</string>
+    <string name="team_role_viewer">Viewer</string>
+    <string name="team_created_success">Team created</string>
+    <string name="team_joined_success">Joined team</string>
+    <string name="team_leave_success">Left team</string>
+    <string name="team_invite_invalid">Invalid invite code</string>
+    <string name="team_already_member">Already a team member</string>
+    <string name="team_invite_share_title">Share Team Invite</string>
+    <string name="team_invite_share_desc">Let others scan QR or copy invite code to join</string>
 </resources>


### PR DESCRIPTION
## Summary
- Team sharing foundation for Issue #31 Phase 1
- AES-256 team key generation and invite code system
- Room database schema for teams and shared credentials
- TeamManager business logic for create/join/leave

## Changes
- `TeamCrypto.kt`: AES-256 key generation, invite codes, encrypt/decrypt
- `Team.kt`: Team/TeamMember data models with role permissions
- `TeamEntity.kt`: Room entities (teams, team_members, shared_credentials)
- `TeamDao.kt`: Database DAO for team operations
- `TeamManager.kt`: Create/join/leave team business logic
- `LockitDatabase.kt`: Database upgraded to v2 with team tables
- Strings and audit actions added

## Test plan
- [ ] Build passes
- [ ] Lint passes
- [ ] Database migration works (fallbackToDestructiveMigration for MVP)
- [ ] Team creation generates valid invite codes
- [ ] Team join parses invite strings correctly

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)