### PR TITLE
feat: WebDAV sync backend implementation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -114,6 +114,9 @@ dependencies {
     // Coroutines
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0")
 
+    // OkHttp for WebDAV
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+
     // Glance (Jetpack Compose for Widgets)
     implementation("androidx.glance:glance:1.1.1")
     implementation("androidx.glance:glance-appwidget:1.1.1")

--- a/app/src/main/java/com/lockit/data/sync/WebDavBackend.kt
+++ b/app/src/main/java/com/lockit/data/sync/WebDavBackend.kt
@@ -2,6 +2,8 @@ package com.lockit.data.sync
 
 import android.content.Context
 import android.util.Log
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.Credentials
@@ -22,6 +24,7 @@ import java.time.Instant
  * - /lockit-sync/manifest.json ← sync metadata
  *
  * Uses optimistic locking with ETag/If-Match for conflict detection.
+ * Credentials stored in EncryptedSharedPreferences for security.
  */
 class WebDavBackend(private val context: Context) : SyncBackend {
 
@@ -43,14 +46,31 @@ class WebDavBackend(private val context: Context) : SyncBackend {
         private val BINARY_MEDIA = "application/octet-stream".toMediaType()
     }
 
+    @Volatile
     private var client: OkHttpClient? = null
+    @Volatile
     private var serverUrl: String? = null
+    @Volatile
     private var username: String? = null
+    @Volatile
     private var password: String? = null
+    @Volatile
     private var basePath: String? = null
 
+    private val masterKey by lazy {
+        MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+    }
+
     private val prefs by lazy {
-        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        EncryptedSharedPreferences.create(
+            context,
+            PREFS_NAME,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
     }
 
     override suspend fun isConfigured(): Boolean {
@@ -70,16 +90,17 @@ class WebDavBackend(private val context: Context) : SyncBackend {
 
         val normalizedUrl = url.trimEnd('/')
 
-        client = OkHttpClient.Builder()
-            .connectTimeout(30, java.util.concurrent.TimeUnit.SECONDS)
-            .readTimeout(60, java.util.concurrent.TimeUnit.SECONDS)
-            .writeTimeout(60, java.util.concurrent.TimeUnit.SECONDS)
-            .build()
-
-        serverUrl = normalizedUrl
-        username = user
-        password = pass
-        basePath = path
+        synchronized(this) {
+            client = OkHttpClient.Builder()
+                .connectTimeout(30, java.util.concurrent.TimeUnit.SECONDS)
+                .readTimeout(60, java.util.concurrent.TimeUnit.SECONDS)
+                .writeTimeout(60, java.util.concurrent.TimeUnit.SECONDS)
+                .build()
+            serverUrl = normalizedUrl
+            username = user
+            password = pass
+            basePath = path
+        }
 
         return withContext(Dispatchers.IO) {
             try {
@@ -91,24 +112,24 @@ class WebDavBackend(private val context: Context) : SyncBackend {
                     .header("Depth", "0")
                     .build()
 
-                val response = client!!.newCall(request).execute()
-
-                if (response.isSuccessful || response.code == 207) {
-                    saveCredentials(normalizedUrl, user, pass, path)
-                    Log.i(TAG, "WebDAV configured: $normalizedUrl$path")
-                    Result.success(Unit)
-                } else if (response.code == 404) {
-                    val createResult = createBaseFolderInternal()
-                    if (createResult.isSuccess) {
+                client!!.newCall(request).execute().use { response ->
+                    if (response.isSuccessful || response.code == 207) {
                         saveCredentials(normalizedUrl, user, pass, path)
+                        Log.i(TAG, "WebDAV configured: $normalizedUrl$path")
                         Result.success(Unit)
+                    } else if (response.code == 404) {
+                        val createResult = createBaseFolderInternal()
+                        if (createResult.isSuccess) {
+                            saveCredentials(normalizedUrl, user, pass, path)
+                            Result.success(Unit)
+                        } else {
+                            Result.failure(IOException("Failed to create folder: ${createResult.exceptionOrNull()?.message}"))
+                        }
+                    } else if (response.code == 401) {
+                        Result.failure(IOException("Authentication failed: invalid username or password"))
                     } else {
-                        Result.failure(IOException("Failed to create folder: ${createResult.exceptionOrNull()?.message}"))
+                        Result.failure(IOException("WebDAV connection failed: HTTP ${response.code}"))
                     }
-                } else if (response.code == 401) {
-                    Result.failure(IOException("Authentication failed: invalid username or password"))
-                } else {
-                    Result.failure(IOException("WebDAV connection failed: HTTP ${response.code}"))
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "WebDAV configure failed: ${e.message}")
@@ -129,20 +150,29 @@ class WebDavBackend(private val context: Context) : SyncBackend {
     private suspend fun createBaseFolderInternal(): Result<Unit> {
         return withContext(Dispatchers.IO) {
             try {
-                val url = "$serverUrl$basePath"
-                val request = Request.Builder()
-                    .url(url)
-                    .method("MKCOL", null)
-                    .header("Authorization", Credentials.basic(username!!, password!!))
-                    .build()
+                val url = serverUrl
+                val path = basePath ?: DEFAULT_BASE_PATH
+                val user = username
+                val pass = password
+                val httpClient = client
 
-                val response = client!!.newCall(request).execute()
-
-                if (response.isSuccessful || response.code == 201) {
-                    Log.i(TAG, "Created WebDAV folder: $url")
-                    Result.success(Unit)
+                if (url == null || user == null || pass == null || httpClient == null) {
+                    Result.failure(IOException("Credentials not configured"))
                 } else {
-                    Result.failure(IOException("MKCOL failed: HTTP ${response.code}"))
+                    val request = Request.Builder()
+                        .url("$url$path")
+                        .method("MKCOL", null)
+                        .header("Authorization", Credentials.basic(user, pass))
+                        .build()
+
+                    httpClient.newCall(request).execute().use { response ->
+                        if (response.isSuccessful || response.code == 201) {
+                            Log.i(TAG, "Created WebDAV folder: $url$path")
+                            Result.success(Unit)
+                        } else {
+                            Result.failure(IOException("MKCOL failed: HTTP ${response.code}"))
+                        }
+                    }
                 }
             } catch (e: Exception) {
                 Result.failure(e)
@@ -158,31 +188,43 @@ class WebDavBackend(private val context: Context) : SyncBackend {
 
         return withContext(Dispatchers.IO) {
             try {
-                val vaultUrl = "$serverUrl$basePath/$VAULT_FILE"
-                val vaultRequest = Request.Builder()
-                    .url(vaultUrl)
-                    .put(encryptedData.toRequestBody(BINARY_MEDIA))
-                    .header("Authorization", Credentials.basic(username!!, password!!))
-                    .build()
+                val url = serverUrl
+                val path = basePath ?: DEFAULT_BASE_PATH
+                val user = username
+                val pass = password
+                val httpClient = client
 
-                val vaultResponse = client!!.newCall(vaultRequest).execute()
-                if (!vaultResponse.isSuccessful) {
-                    Result.failure(IOException("Upload vault failed: HTTP ${vaultResponse.code}"))
+                if (url == null || user == null || pass == null || httpClient == null) {
+                    Result.failure(IOException("Credentials not configured"))
                 } else {
-                    val manifestUrl = "$serverUrl$basePath/$MANIFEST_FILE"
-                    val manifestJson = manifest.toJson()
-                    val manifestRequest = Request.Builder()
-                        .url(manifestUrl)
-                        .put(manifestJson.toByteArray(Charsets.UTF_8).toRequestBody(JSON_MEDIA))
-                        .header("Authorization", Credentials.basic(username!!, password!!))
+                    val vaultUrl = "$url$path/$VAULT_FILE"
+                    val vaultRequest = Request.Builder()
+                        .url(vaultUrl)
+                        .put(encryptedData.toRequestBody(BINARY_MEDIA))
+                        .header("Authorization", Credentials.basic(user, pass))
                         .build()
 
-                    val manifestResponse = client!!.newCall(manifestRequest).execute()
-                    if (!manifestResponse.isSuccessful) {
-                        Result.failure(IOException("Upload manifest failed: HTTP ${manifestResponse.code}"))
-                    } else {
-                        Log.i(TAG, "Uploaded vault ($encryptedData.size bytes) + manifest")
-                        Result.success(Unit)
+                    httpClient.newCall(vaultRequest).execute().use { vaultResponse ->
+                        if (!vaultResponse.isSuccessful) {
+                            Result.failure(IOException("Upload vault failed: HTTP ${vaultResponse.code}"))
+                        } else {
+                            val manifestUrl = "$url$path/$MANIFEST_FILE"
+                            val manifestJson = manifest.toJson()
+                            val manifestRequest = Request.Builder()
+                                .url(manifestUrl)
+                                .put(manifestJson.toByteArray(Charsets.UTF_8).toRequestBody(JSON_MEDIA))
+                                .header("Authorization", Credentials.basic(user, pass))
+                                .build()
+
+                            httpClient.newCall(manifestRequest).execute().use { manifestResponse ->
+                                if (!manifestResponse.isSuccessful) {
+                                    Result.failure(IOException("Upload manifest failed: HTTP ${manifestResponse.code}"))
+                                } else {
+                                    Log.i(TAG, "Uploaded vault (${encryptedData.size} bytes) + manifest")
+                                    Result.success(Unit)
+                                }
+                            }
+                        }
                     }
                 }
             } catch (e: Exception) {
@@ -197,27 +239,37 @@ class WebDavBackend(private val context: Context) : SyncBackend {
 
         return withContext(Dispatchers.IO) {
             try {
-                val vaultUrl = "$serverUrl$basePath/$VAULT_FILE"
-                val request = Request.Builder()
-                    .url(vaultUrl)
-                    .get()
-                    .header("Authorization", Credentials.basic(username!!, password!!))
-                    .build()
+                val url = serverUrl
+                val path = basePath ?: DEFAULT_BASE_PATH
+                val user = username
+                val pass = password
+                val httpClient = client
 
-                val response = client!!.newCall(request).execute()
-
-                if (response.isSuccessful) {
-                    val data = response.body?.bytes()
-                    if (data != null) {
-                        Log.i(TAG, "Downloaded vault: ${data.size} bytes")
-                        Result.success(data)
-                    } else {
-                        Result.failure(IOException("Empty response body"))
-                    }
-                } else if (response.code == 404) {
-                    Result.failure(IOException("No vault.enc in cloud"))
+                if (url == null || user == null || pass == null || httpClient == null) {
+                    Result.failure(IOException("Credentials not configured"))
                 } else {
-                    Result.failure(IOException("Download failed: HTTP ${response.code}"))
+                    val vaultUrl = "$url$path/$VAULT_FILE"
+                    val request = Request.Builder()
+                        .url(vaultUrl)
+                        .get()
+                        .header("Authorization", Credentials.basic(user, pass))
+                        .build()
+
+                    httpClient.newCall(request).execute().use { response ->
+                        if (response.isSuccessful) {
+                            val data = response.body?.bytes()
+                            if (data != null) {
+                                Log.i(TAG, "Downloaded vault: ${data.size} bytes")
+                                Result.success(data)
+                            } else {
+                                Result.failure(IOException("Empty response body"))
+                            }
+                        } else if (response.code == 404) {
+                            Result.failure(IOException("No vault.enc in cloud"))
+                        } else {
+                            Result.failure(IOException("Download failed: HTTP ${response.code}"))
+                        }
+                    }
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Download failed: ${e.message}")
@@ -231,28 +283,38 @@ class WebDavBackend(private val context: Context) : SyncBackend {
 
         return withContext(Dispatchers.IO) {
             try {
-                val manifestUrl = "$serverUrl$basePath/$MANIFEST_FILE"
-                val request = Request.Builder()
-                    .url(manifestUrl)
-                    .get()
-                    .header("Authorization", Credentials.basic(username!!, password!!))
-                    .build()
+                val url = serverUrl
+                val path = basePath ?: DEFAULT_BASE_PATH
+                val user = username
+                val pass = password
+                val httpClient = client
 
-                val response = client!!.newCall(request).execute()
-
-                if (response.isSuccessful) {
-                    val json = response.body?.string()
-                    if (json != null) {
-                        val manifest = SyncManifest.fromJson(json)
-                        Log.i(TAG, "Got manifest: checksum=${manifest.vaultChecksum}")
-                        Result.success(manifest)
-                    } else {
-                        Result.success(null)
-                    }
-                } else if (response.code == 404) {
-                    Result.success(null)
+                if (url == null || user == null || pass == null || httpClient == null) {
+                    Result.failure(IOException("Credentials not configured"))
                 } else {
-                    Result.failure(IOException("Get manifest failed: HTTP ${response.code}"))
+                    val manifestUrl = "$url$path/$MANIFEST_FILE"
+                    val request = Request.Builder()
+                        .url(manifestUrl)
+                        .get()
+                        .header("Authorization", Credentials.basic(user, pass))
+                        .build()
+
+                    httpClient.newCall(request).execute().use { response ->
+                        if (response.isSuccessful) {
+                            val json = response.body?.string()
+                            if (json != null) {
+                                val manifest = SyncManifest.fromJson(json)
+                                Log.i(TAG, "Got manifest: checksum=${manifest.vaultChecksum}")
+                                Result.success(manifest)
+                            } else {
+                                Result.success(null)
+                            }
+                        } else if (response.code == 404) {
+                            Result.success(null)
+                        } else {
+                            Result.failure(IOException("Get manifest failed: HTTP ${response.code}"))
+                        }
+                    }
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Get manifest failed: ${e.message}")
@@ -266,32 +328,42 @@ class WebDavBackend(private val context: Context) : SyncBackend {
 
         return withContext(Dispatchers.IO) {
             try {
-                val vaultUrl = "$serverUrl$basePath/$VAULT_FILE"
-                val vaultRequest = Request.Builder()
-                    .url(vaultUrl)
-                    .delete()
-                    .header("Authorization", Credentials.basic(username!!, password!!))
-                    .build()
-                client!!.newCall(vaultRequest).execute()
+                val url = serverUrl
+                val path = basePath ?: DEFAULT_BASE_PATH
+                val user = username
+                val pass = password
+                val httpClient = client
 
-                val manifestUrl = "$serverUrl$basePath/$MANIFEST_FILE"
-                val manifestRequest = Request.Builder()
-                    .url(manifestUrl)
-                    .delete()
-                    .header("Authorization", Credentials.basic(username!!, password!!))
-                    .build()
-                client!!.newCall(manifestRequest).execute()
+                if (url == null || user == null || pass == null || httpClient == null) {
+                    Result.failure(IOException("Credentials not configured"))
+                } else {
+                    // Delete vault.enc
+                    val vaultRequest = Request.Builder()
+                        .url("$url$path/$VAULT_FILE")
+                        .delete()
+                        .header("Authorization", Credentials.basic(user, pass))
+                        .build()
+                    httpClient.newCall(vaultRequest).execute().use { }
 
-                val folderUrl = "$serverUrl$basePath"
-                val folderRequest = Request.Builder()
-                    .url(folderUrl)
-                    .delete()
-                    .header("Authorization", Credentials.basic(username!!, password!!))
-                    .build()
-                client!!.newCall(folderRequest).execute()
+                    // Delete manifest.json
+                    val manifestRequest = Request.Builder()
+                        .url("$url$path/$MANIFEST_FILE")
+                        .delete()
+                        .header("Authorization", Credentials.basic(user, pass))
+                        .build()
+                    httpClient.newCall(manifestRequest).execute().use { }
 
-                Log.i(TAG, "Deleted all sync data")
-                Result.success(Unit)
+                    // Delete folder
+                    val folderRequest = Request.Builder()
+                        .url("$url$path")
+                        .delete()
+                        .header("Authorization", Credentials.basic(user, pass))
+                        .build()
+                    httpClient.newCall(folderRequest).execute().use { }
+
+                    Log.i(TAG, "Deleted all sync data")
+                    Result.success(Unit)
+                }
             } catch (e: Exception) {
                 Log.e(TAG, "Delete failed: ${e.message}")
                 Result.failure(e)
@@ -301,27 +373,31 @@ class WebDavBackend(private val context: Context) : SyncBackend {
 
     override suspend fun disconnect() {
         prefs.edit().clear().apply()
-        client = null
-        serverUrl = null
-        username = null
-        password = null
-        basePath = null
+        synchronized(this) {
+            client = null
+            serverUrl = null
+            username = null
+            password = null
+            basePath = null
+        }
         Log.i(TAG, "WebDAV disconnected")
     }
 
     private fun loadCredentials() {
-        if (serverUrl == null) {
-            serverUrl = prefs.getString(KEY_SERVER_URL, null)
-            username = prefs.getString(KEY_USERNAME, null)
-            password = prefs.getString(KEY_PASSWORD, null)
-            basePath = prefs.getString(KEY_BASE_PATH, DEFAULT_BASE_PATH)
+        synchronized(this) {
+            if (serverUrl == null) {
+                serverUrl = prefs.getString(KEY_SERVER_URL, null)
+                username = prefs.getString(KEY_USERNAME, null)
+                password = prefs.getString(KEY_PASSWORD, null)
+                basePath = prefs.getString(KEY_BASE_PATH, DEFAULT_BASE_PATH)
 
-            if (serverUrl != null && username != null && password != null) {
-                client = OkHttpClient.Builder()
-                    .connectTimeout(30, java.util.concurrent.TimeUnit.SECONDS)
-                    .readTimeout(60, java.util.concurrent.TimeUnit.SECONDS)
-                    .writeTimeout(60, java.util.concurrent.TimeUnit.SECONDS)
-                    .build()
+                if (serverUrl != null && username != null && password != null) {
+                    client = OkHttpClient.Builder()
+                        .connectTimeout(30, java.util.concurrent.TimeUnit.SECONDS)
+                        .readTimeout(60, java.util.concurrent.TimeUnit.SECONDS)
+                        .writeTimeout(60, java.util.concurrent.TimeUnit.SECONDS)
+                        .build()
+                }
             }
         }
     }
@@ -331,17 +407,27 @@ class WebDavBackend(private val context: Context) : SyncBackend {
 
         return withContext(Dispatchers.IO) {
             try {
-                val vaultUrl = "$serverUrl$basePath/$VAULT_FILE"
-                val request = Request.Builder()
-                    .url(vaultUrl)
-                    .method("PROPFIND", null)
-                    .header("Authorization", Credentials.basic(username!!, password!!))
-                    .header("Depth", "0")
-                    .build()
+                val url = serverUrl
+                val path = basePath ?: DEFAULT_BASE_PATH
+                val user = username
+                val pass = password
+                val httpClient = client
 
-                val response = client!!.newCall(request).execute()
-                val body = response.body?.string()
-                body?.let { parseETag(it) }
+                if (url == null || user == null || pass == null || httpClient == null) {
+                    null
+                } else {
+                    val request = Request.Builder()
+                        .url("$url$path/$VAULT_FILE")
+                        .method("PROPFIND", null)
+                        .header("Authorization", Credentials.basic(user, pass))
+                        .header("Depth", "0")
+                        .build()
+
+                    httpClient.newCall(request).execute().use { response ->
+                        val body = response.body?.string()
+                        body?.let { parseETag(it) }
+                    }
+                }
             } catch (e: Exception) {
                 null
             }
@@ -362,25 +448,51 @@ class WebDavBackend(private val context: Context) : SyncBackend {
 
         return withContext(Dispatchers.IO) {
             try {
-                val vaultUrl = "$serverUrl$basePath/$VAULT_FILE"
+                val url = serverUrl
+                val path = basePath ?: DEFAULT_BASE_PATH
+                val user = username
+                val pass = password
+                val httpClient = client
 
-                val builder = Request.Builder()
-                    .url(vaultUrl)
-                    .put(encryptedData.toRequestBody(BINARY_MEDIA))
-                    .header("Authorization", Credentials.basic(username!!, password!!))
-
-                if (expectedETag != null) {
-                    builder.header("If-Match", "\"$expectedETag\"")
-                }
-
-                val response = client!!.newCall(builder.build()).execute()
-
-                if (response.isSuccessful) {
-                    uploadVault(encryptedData, manifest)
-                } else if (response.code == 412) {
-                    Result.failure(IOException("CONFLICT: ETag mismatch, another device modified the vault"))
+                if (url == null || user == null || pass == null || httpClient == null) {
+                    Result.failure(IOException("Credentials not configured"))
                 } else {
-                    Result.failure(IOException("Upload failed: HTTP ${response.code}"))
+                    val vaultUrl = "$url$path/$VAULT_FILE"
+
+                    val builder = Request.Builder()
+                        .url(vaultUrl)
+                        .put(encryptedData.toRequestBody(BINARY_MEDIA))
+                        .header("Authorization", Credentials.basic(user, pass))
+
+                    if (expectedETag != null) {
+                        builder.header("If-Match", "\"$expectedETag\"")
+                    }
+
+                    httpClient.newCall(builder.build()).execute().use { response ->
+                        if (response.isSuccessful) {
+                            // Vault uploaded with locking, now upload manifest separately
+                            val manifestUrl = "$url$path/$MANIFEST_FILE"
+                            val manifestJson = manifest.toJson()
+                            val manifestRequest = Request.Builder()
+                                .url(manifestUrl)
+                                .put(manifestJson.toByteArray(Charsets.UTF_8).toRequestBody(JSON_MEDIA))
+                                .header("Authorization", Credentials.basic(user, pass))
+                                .build()
+
+                            httpClient.newCall(manifestRequest).execute().use { manifestResponse ->
+                                if (manifestResponse.isSuccessful) {
+                                    Log.i(TAG, "Uploaded vault with locking (${encryptedData.size} bytes)")
+                                    Result.success(Unit)
+                                } else {
+                                    Result.failure(IOException("Upload manifest failed: HTTP ${manifestResponse.code}"))
+                                }
+                            }
+                        } else if (response.code == 412) {
+                            Result.failure(IOException("CONFLICT: ETag mismatch, another device modified the vault"))
+                        } else {
+                            Result.failure(IOException("Upload failed: HTTP ${response.code}"))
+                        }
+                    }
                 }
             } catch (e: Exception) {
                 Result.failure(e)

--- a/app/src/main/java/com/lockit/data/sync/WebDavBackend.kt
+++ b/app/src/main/java/com/lockit/data/sync/WebDavBackend.kt
@@ -88,6 +88,11 @@ class WebDavBackend(private val context: Context) : SyncBackend {
             return Result.failure(IllegalArgumentException("Missing required credentials: serverUrl, username, password"))
         }
 
+        // Security: Enforce HTTPS to protect credentials
+        if (!url.startsWith("https://", ignoreCase = true)) {
+            return Result.failure(SecurityException("HTTPS is required for WebDAV sync to protect credentials"))
+        }
+
         val normalizedUrl = url.trimEnd('/')
 
         synchronized(this) {
@@ -257,12 +262,19 @@ class WebDavBackend(private val context: Context) : SyncBackend {
 
                     httpClient.newCall(request).execute().use { response ->
                         if (response.isSuccessful) {
-                            val data = response.body?.bytes()
-                            if (data != null) {
-                                Log.i(TAG, "Downloaded vault: ${data.size} bytes")
-                                Result.success(data)
+                            val body = response.body
+                            // OOM protection: check content length before loading into memory
+                            val contentLength = body?.contentLength() ?: -1
+                            if (contentLength > 50 * 1024 * 1024) {
+                                Result.failure(IOException("Vault too large ($contentLength bytes), max 50MB"))
                             } else {
-                                Result.failure(IOException("Empty response body"))
+                                val data = body?.bytes()
+                                if (data != null) {
+                                    Log.i(TAG, "Downloaded vault: ${data.size} bytes")
+                                    Result.success(data)
+                                } else {
+                                    Result.failure(IOException("Empty response body"))
+                                }
                             }
                         } else if (response.code == 404) {
                             Result.failure(IOException("No vault.enc in cloud"))
@@ -435,7 +447,8 @@ class WebDavBackend(private val context: Context) : SyncBackend {
     }
 
     private fun parseETag(xmlResponse: String): String? {
-        val etagPattern = Regex("<getetag>([^<]+)</getetag>", RegexOption.IGNORE_CASE)
+        // Handle XML namespaces like <d:getetag> (Nextcloud, Seafile, etc.)
+        val etagPattern = Regex("<(?:\\w+:)?getetag>([^<]+)</(?:\\w+:)?getetag>", RegexOption.IGNORE_CASE)
         return etagPattern.find(xmlResponse)?.groupValues?.getOrNull(1)?.trim('"')
     }
 

--- a/app/src/main/java/com/lockit/data/sync/WebDavBackend.kt
+++ b/app/src/main/java/com/lockit/data/sync/WebDavBackend.kt
@@ -1,0 +1,390 @@
+package com.lockit.data.sync
+
+import android.content.Context
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.Credentials
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.IOException
+import java.time.Instant
+
+/**
+ * WebDAV backend for vault sync.
+ * Implements SyncBackend interface with standard WebDAV protocol.
+ * Supports: 坚果云, Nextcloud, Seafile, OwnCloud, and any WebDAV server.
+ *
+ * File structure on WebDAV server:
+ * - /lockit-sync/vault.enc  ← encrypted vault.db
+ * - /lockit-sync/manifest.json ← sync metadata
+ *
+ * Uses optimistic locking with ETag/If-Match for conflict detection.
+ */
+class WebDavBackend(private val context: Context) : SyncBackend {
+
+    override val name = "WebDAV"
+
+    companion object {
+        private const val TAG = "WebDavBackend"
+        private const val PREFS_NAME = "webdav_prefs"
+        private const val KEY_SERVER_URL = "server_url"
+        private const val KEY_USERNAME = "username"
+        private const val KEY_PASSWORD = "password"
+        private const val KEY_BASE_PATH = "base_path"
+
+        private const val DEFAULT_BASE_PATH = "/lockit-sync"
+        private const val VAULT_FILE = "vault.enc"
+        private const val MANIFEST_FILE = "manifest.json"
+
+        private val JSON_MEDIA = "application/json; charset=utf-8".toMediaType()
+        private val BINARY_MEDIA = "application/octet-stream".toMediaType()
+    }
+
+    private var client: OkHttpClient? = null
+    private var serverUrl: String? = null
+    private var username: String? = null
+    private var password: String? = null
+    private var basePath: String? = null
+
+    private val prefs by lazy {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    }
+
+    override suspend fun isConfigured(): Boolean {
+        return prefs.getString(KEY_SERVER_URL, null) != null &&
+               prefs.getString(KEY_USERNAME, null) != null
+    }
+
+    override suspend fun configure(credentials: Map<String, String>): Result<Unit> {
+        val url = credentials["serverUrl"] ?: credentials["url"]
+        val user = credentials["username"] ?: credentials["user"]
+        val pass = credentials["password"] ?: credentials["pass"]
+        val path = credentials["basePath"] ?: DEFAULT_BASE_PATH
+
+        if (url == null || user == null || pass == null) {
+            return Result.failure(IllegalArgumentException("Missing required credentials: serverUrl, username, password"))
+        }
+
+        val normalizedUrl = url.trimEnd('/')
+
+        client = OkHttpClient.Builder()
+            .connectTimeout(30, java.util.concurrent.TimeUnit.SECONDS)
+            .readTimeout(60, java.util.concurrent.TimeUnit.SECONDS)
+            .writeTimeout(60, java.util.concurrent.TimeUnit.SECONDS)
+            .build()
+
+        serverUrl = normalizedUrl
+        username = user
+        password = pass
+        basePath = path
+
+        return withContext(Dispatchers.IO) {
+            try {
+                val testUrl = "$normalizedUrl$path"
+                val request = Request.Builder()
+                    .url(testUrl)
+                    .method("PROPFIND", null)
+                    .header("Authorization", Credentials.basic(user, pass))
+                    .header("Depth", "0")
+                    .build()
+
+                val response = client!!.newCall(request).execute()
+
+                if (response.isSuccessful || response.code == 207) {
+                    saveCredentials(normalizedUrl, user, pass, path)
+                    Log.i(TAG, "WebDAV configured: $normalizedUrl$path")
+                    Result.success(Unit)
+                } else if (response.code == 404) {
+                    val createResult = createBaseFolderInternal()
+                    if (createResult.isSuccess) {
+                        saveCredentials(normalizedUrl, user, pass, path)
+                        Result.success(Unit)
+                    } else {
+                        Result.failure(IOException("Failed to create folder: ${createResult.exceptionOrNull()?.message}"))
+                    }
+                } else if (response.code == 401) {
+                    Result.failure(IOException("Authentication failed: invalid username or password"))
+                } else {
+                    Result.failure(IOException("WebDAV connection failed: HTTP ${response.code}"))
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "WebDAV configure failed: ${e.message}")
+                Result.failure(e)
+            }
+        }
+    }
+
+    private fun saveCredentials(url: String, user: String, pass: String, path: String) {
+        prefs.edit()
+            .putString(KEY_SERVER_URL, url)
+            .putString(KEY_USERNAME, user)
+            .putString(KEY_PASSWORD, pass)
+            .putString(KEY_BASE_PATH, path)
+            .apply()
+    }
+
+    private suspend fun createBaseFolderInternal(): Result<Unit> {
+        return withContext(Dispatchers.IO) {
+            try {
+                val url = "$serverUrl$basePath"
+                val request = Request.Builder()
+                    .url(url)
+                    .method("MKCOL", null)
+                    .header("Authorization", Credentials.basic(username!!, password!!))
+                    .build()
+
+                val response = client!!.newCall(request).execute()
+
+                if (response.isSuccessful || response.code == 201) {
+                    Log.i(TAG, "Created WebDAV folder: $url")
+                    Result.success(Unit)
+                } else {
+                    Result.failure(IOException("MKCOL failed: HTTP ${response.code}"))
+                }
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+    }
+
+    override suspend fun uploadVault(
+        encryptedData: ByteArray,
+        manifest: SyncManifest
+    ): Result<Unit> {
+        loadCredentials()
+
+        return withContext(Dispatchers.IO) {
+            try {
+                val vaultUrl = "$serverUrl$basePath/$VAULT_FILE"
+                val vaultRequest = Request.Builder()
+                    .url(vaultUrl)
+                    .put(encryptedData.toRequestBody(BINARY_MEDIA))
+                    .header("Authorization", Credentials.basic(username!!, password!!))
+                    .build()
+
+                val vaultResponse = client!!.newCall(vaultRequest).execute()
+                if (!vaultResponse.isSuccessful) {
+                    Result.failure(IOException("Upload vault failed: HTTP ${vaultResponse.code}"))
+                } else {
+                    val manifestUrl = "$serverUrl$basePath/$MANIFEST_FILE"
+                    val manifestJson = manifest.toJson()
+                    val manifestRequest = Request.Builder()
+                        .url(manifestUrl)
+                        .put(manifestJson.toByteArray(Charsets.UTF_8).toRequestBody(JSON_MEDIA))
+                        .header("Authorization", Credentials.basic(username!!, password!!))
+                        .build()
+
+                    val manifestResponse = client!!.newCall(manifestRequest).execute()
+                    if (!manifestResponse.isSuccessful) {
+                        Result.failure(IOException("Upload manifest failed: HTTP ${manifestResponse.code}"))
+                    } else {
+                        Log.i(TAG, "Uploaded vault ($encryptedData.size bytes) + manifest")
+                        Result.success(Unit)
+                    }
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Upload failed: ${e.message}")
+                Result.failure(e)
+            }
+        }
+    }
+
+    override suspend fun downloadVault(): Result<ByteArray> {
+        loadCredentials()
+
+        return withContext(Dispatchers.IO) {
+            try {
+                val vaultUrl = "$serverUrl$basePath/$VAULT_FILE"
+                val request = Request.Builder()
+                    .url(vaultUrl)
+                    .get()
+                    .header("Authorization", Credentials.basic(username!!, password!!))
+                    .build()
+
+                val response = client!!.newCall(request).execute()
+
+                if (response.isSuccessful) {
+                    val data = response.body?.bytes()
+                    if (data != null) {
+                        Log.i(TAG, "Downloaded vault: ${data.size} bytes")
+                        Result.success(data)
+                    } else {
+                        Result.failure(IOException("Empty response body"))
+                    }
+                } else if (response.code == 404) {
+                    Result.failure(IOException("No vault.enc in cloud"))
+                } else {
+                    Result.failure(IOException("Download failed: HTTP ${response.code}"))
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Download failed: ${e.message}")
+                Result.failure(e)
+            }
+        }
+    }
+
+    override suspend fun getManifest(): Result<SyncManifest?> {
+        loadCredentials()
+
+        return withContext(Dispatchers.IO) {
+            try {
+                val manifestUrl = "$serverUrl$basePath/$MANIFEST_FILE"
+                val request = Request.Builder()
+                    .url(manifestUrl)
+                    .get()
+                    .header("Authorization", Credentials.basic(username!!, password!!))
+                    .build()
+
+                val response = client!!.newCall(request).execute()
+
+                if (response.isSuccessful) {
+                    val json = response.body?.string()
+                    if (json != null) {
+                        val manifest = SyncManifest.fromJson(json)
+                        Log.i(TAG, "Got manifest: checksum=${manifest.vaultChecksum}")
+                        Result.success(manifest)
+                    } else {
+                        Result.success(null)
+                    }
+                } else if (response.code == 404) {
+                    Result.success(null)
+                } else {
+                    Result.failure(IOException("Get manifest failed: HTTP ${response.code}"))
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Get manifest failed: ${e.message}")
+                Result.failure(e)
+            }
+        }
+    }
+
+    override suspend fun deleteSyncData(): Result<Unit> {
+        loadCredentials()
+
+        return withContext(Dispatchers.IO) {
+            try {
+                val vaultUrl = "$serverUrl$basePath/$VAULT_FILE"
+                val vaultRequest = Request.Builder()
+                    .url(vaultUrl)
+                    .delete()
+                    .header("Authorization", Credentials.basic(username!!, password!!))
+                    .build()
+                client!!.newCall(vaultRequest).execute()
+
+                val manifestUrl = "$serverUrl$basePath/$MANIFEST_FILE"
+                val manifestRequest = Request.Builder()
+                    .url(manifestUrl)
+                    .delete()
+                    .header("Authorization", Credentials.basic(username!!, password!!))
+                    .build()
+                client!!.newCall(manifestRequest).execute()
+
+                val folderUrl = "$serverUrl$basePath"
+                val folderRequest = Request.Builder()
+                    .url(folderUrl)
+                    .delete()
+                    .header("Authorization", Credentials.basic(username!!, password!!))
+                    .build()
+                client!!.newCall(folderRequest).execute()
+
+                Log.i(TAG, "Deleted all sync data")
+                Result.success(Unit)
+            } catch (e: Exception) {
+                Log.e(TAG, "Delete failed: ${e.message}")
+                Result.failure(e)
+            }
+        }
+    }
+
+    override suspend fun disconnect() {
+        prefs.edit().clear().apply()
+        client = null
+        serverUrl = null
+        username = null
+        password = null
+        basePath = null
+        Log.i(TAG, "WebDAV disconnected")
+    }
+
+    private fun loadCredentials() {
+        if (serverUrl == null) {
+            serverUrl = prefs.getString(KEY_SERVER_URL, null)
+            username = prefs.getString(KEY_USERNAME, null)
+            password = prefs.getString(KEY_PASSWORD, null)
+            basePath = prefs.getString(KEY_BASE_PATH, DEFAULT_BASE_PATH)
+
+            if (serverUrl != null && username != null && password != null) {
+                client = OkHttpClient.Builder()
+                    .connectTimeout(30, java.util.concurrent.TimeUnit.SECONDS)
+                    .readTimeout(60, java.util.concurrent.TimeUnit.SECONDS)
+                    .writeTimeout(60, java.util.concurrent.TimeUnit.SECONDS)
+                    .build()
+            }
+        }
+    }
+
+    suspend fun getVaultETag(): String? {
+        loadCredentials()
+
+        return withContext(Dispatchers.IO) {
+            try {
+                val vaultUrl = "$serverUrl$basePath/$VAULT_FILE"
+                val request = Request.Builder()
+                    .url(vaultUrl)
+                    .method("PROPFIND", null)
+                    .header("Authorization", Credentials.basic(username!!, password!!))
+                    .header("Depth", "0")
+                    .build()
+
+                val response = client!!.newCall(request).execute()
+                val body = response.body?.string()
+                body?.let { parseETag(it) }
+            } catch (e: Exception) {
+                null
+            }
+        }
+    }
+
+    private fun parseETag(xmlResponse: String): String? {
+        val etagPattern = Regex("<getetag>([^<]+)</getetag>", RegexOption.IGNORE_CASE)
+        return etagPattern.find(xmlResponse)?.groupValues?.getOrNull(1)?.trim('"')
+    }
+
+    suspend fun uploadVaultWithLocking(
+        encryptedData: ByteArray,
+        manifest: SyncManifest,
+        expectedETag: String?
+    ): Result<Unit> {
+        loadCredentials()
+
+        return withContext(Dispatchers.IO) {
+            try {
+                val vaultUrl = "$serverUrl$basePath/$VAULT_FILE"
+
+                val builder = Request.Builder()
+                    .url(vaultUrl)
+                    .put(encryptedData.toRequestBody(BINARY_MEDIA))
+                    .header("Authorization", Credentials.basic(username!!, password!!))
+
+                if (expectedETag != null) {
+                    builder.header("If-Match", "\"$expectedETag\"")
+                }
+
+                val response = client!!.newCall(builder.build()).execute()
+
+                if (response.isSuccessful) {
+                    uploadVault(encryptedData, manifest)
+                } else if (response.code == 412) {
+                    Result.failure(IOException("CONFLICT: ETag mismatch, another device modified the vault"))
+                } else {
+                    Result.failure(IOException("Upload failed: HTTP ${response.code}"))
+                }
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/lockit/data/sync/WebDavBackend.kt
+++ b/app/src/main/java/com/lockit/data/sync/WebDavBackend.kt
@@ -96,16 +96,20 @@ class WebDavBackend(private val context: Context) : SyncBackend {
         val normalizedUrl = url.trimEnd('/')
 
         synchronized(this) {
-            client = OkHttpClient.Builder()
+            val newClient = OkHttpClient.Builder()
                 .connectTimeout(30, java.util.concurrent.TimeUnit.SECONDS)
                 .readTimeout(60, java.util.concurrent.TimeUnit.SECONDS)
                 .writeTimeout(60, java.util.concurrent.TimeUnit.SECONDS)
                 .build()
+            client = newClient
             serverUrl = normalizedUrl
             username = user
             password = pass
             basePath = path
         }
+
+        // Capture client in local variable to prevent NPE from concurrent disconnect()
+        val httpClient = client!!
 
         return withContext(Dispatchers.IO) {
             try {
@@ -117,7 +121,7 @@ class WebDavBackend(private val context: Context) : SyncBackend {
                     .header("Depth", "0")
                     .build()
 
-                client!!.newCall(request).execute().use { response ->
+                httpClient.newCall(request).execute().use { response ->
                     if (response.isSuccessful || response.code == 207) {
                         saveCredentials(normalizedUrl, user, pass, path)
                         Log.i(TAG, "WebDAV configured: $normalizedUrl$path")
@@ -223,7 +227,14 @@ class WebDavBackend(private val context: Context) : SyncBackend {
 
                             httpClient.newCall(manifestRequest).execute().use { manifestResponse ->
                                 if (!manifestResponse.isSuccessful) {
-                                    Result.failure(IOException("Upload manifest failed: HTTP ${manifestResponse.code}"))
+                                    // Manifest failed: delete vault to maintain consistency
+                                    val deleteRequest = Request.Builder()
+                                        .url(vaultUrl)
+                                        .delete()
+                                        .header("Authorization", Credentials.basic(user, pass))
+                                        .build()
+                                    httpClient.newCall(deleteRequest).execute().use { }
+                                    Result.failure(IOException("Upload manifest failed (vault cleaned): HTTP ${manifestResponse.code}"))
                                 } else {
                                     Log.i(TAG, "Uploaded vault (${encryptedData.size} bytes) + manifest")
                                     Result.success(Unit)
@@ -265,8 +276,10 @@ class WebDavBackend(private val context: Context) : SyncBackend {
                             val body = response.body
                             // OOM protection: check content length before loading into memory
                             val contentLength = body?.contentLength() ?: -1
-                            if (contentLength > 50 * 1024 * 1024) {
-                                Result.failure(IOException("Vault too large ($contentLength bytes), max 50MB"))
+                            val MAX_VAULT_SIZE = 50 * 1024 * 1024 // 50MB
+                            if (contentLength > MAX_VAULT_SIZE || contentLength == -1L) {
+                                // Reject large files or unknown size (missing Content-Length header)
+                                Result.failure(IOException("Vault size unknown or too large ($contentLength bytes), max $MAX_VAULT_SIZE"))
                             } else {
                                 val data = body?.bytes()
                                 if (data != null) {

--- a/app/src/main/java/com/lockit/data/vault/CodingPlanPrefs.kt
+++ b/app/src/main/java/com/lockit/data/vault/CodingPlanPrefs.kt
@@ -171,6 +171,9 @@ object CodingPlanPrefs {
     fun getCachedProvider(context: Context): String? =
         getPrefs(context).getString(KEY_QUOTA_CACHE_PROVIDER, null)
 
+    fun getCacheTimestamp(context: Context): Long =
+        getPrefs(context).getLong(KEY_QUOTA_CACHE_TIME, 0)
+
     fun clearQuotaCache(context: Context) {
         getPrefs(context).edit()
             .remove(KEY_QUOTA_CACHE)

--- a/app/src/main/java/com/lockit/domain/CodingPlanPrefetchState.kt
+++ b/app/src/main/java/com/lockit/domain/CodingPlanPrefetchState.kt
@@ -18,6 +18,10 @@ object CodingPlanPrefetchState {
     private val _error = MutableStateFlow<String?>(null)
     val error: StateFlow<String?> = _error.asStateFlow()
 
+    // Cache timestamp (epoch millis) - shows how old cached data is
+    private val _cacheTimestamp = MutableStateFlow(0L)
+    val cacheTimestamp: StateFlow<Long> = _cacheTimestamp.asStateFlow()
+
     var hasPrefetched: Boolean = false
 
     // Setter functions for updating state
@@ -33,11 +37,16 @@ object CodingPlanPrefetchState {
         _error.value = value
     }
 
+    fun setCacheTimestamp(value: Long) {
+        _cacheTimestamp.value = value
+    }
+
     // Convenience function to reset all state
     fun reset() {
         _isLoading.value = false
         _quota.value = null
         _error.value = null
+        _cacheTimestamp.value = 0L
         hasPrefetched = false
     }
 }

--- a/app/src/main/java/com/lockit/ui/MainActivity.kt
+++ b/app/src/main/java/com/lockit/ui/MainActivity.kt
@@ -122,9 +122,11 @@ class MainActivity : FragmentActivity() {
 
             // Step 1: Load cached quota immediately (instant display, no loading spinner)
             val cachedQuota = CodingPlanPrefs.loadQuotaCache(app)
+            val cacheTime = CodingPlanPrefs.getCacheTimestamp(app)
             if (cachedQuota != null) {
                 CodingPlanPrefetchState.setQuota(cachedQuota)
                 CodingPlanPrefetchState.setError(null)
+                CodingPlanPrefetchState.setCacheTimestamp(cacheTime)
             }
 
             // Step 2: Start background refresh (update with fresh data)
@@ -141,6 +143,7 @@ class MainActivity : FragmentActivity() {
                             }
                             CodingPlanPrefetchState.setQuota(quota)
                             CodingPlanPrefetchState.setError(if (quota == null) "NO_QUOTA_DATA" else null)
+                            CodingPlanPrefetchState.setCacheTimestamp(System.currentTimeMillis())
                             // Save to cache for next startup
                             if (quota != null) {
                                 CodingPlanPrefs.saveQuotaCache(app, quota, provider)

--- a/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
@@ -231,6 +231,8 @@ class ReposViewModel(app: LockitApp) : ViewModel() {
         if (CodingPlanPrefetchState.isLoading.value) {
             _isQuotaLoading.value = true
             hasAutoFetchedQuota = true
+            // Show cached quota during background refresh (instant display)
+            _codingPlanQuota.value = CodingPlanPrefetchState.quota.value
             return
         }
 
@@ -328,6 +330,14 @@ fun ReposScreen(
     val prefetchLoading by CodingPlanPrefetchState.isLoading.collectAsStateWithLifecycle()
     val prefetchQuota by CodingPlanPrefetchState.quota.collectAsStateWithLifecycle()
     val prefetchError by CodingPlanPrefetchState.error.collectAsStateWithLifecycle()
+    val prefetchCacheTimestamp by CodingPlanPrefetchState.cacheTimestamp.collectAsStateWithLifecycle()
+
+    // Calculate cache age in minutes (how old is the cached data)
+    val cacheAgeMinutes = remember(prefetchCacheTimestamp) {
+        if (prefetchCacheTimestamp > 0) {
+            ((System.currentTimeMillis() - prefetchCacheTimestamp) / 60000).toInt()
+        } else 0
+    }
 
     // When prefetch completes (success or failure), update ViewModel quota
     LaunchedEffect(prefetchLoading, prefetchQuota, prefetchError) {
@@ -451,6 +461,7 @@ fun ReposScreen(
                         isLoading = isQuotaLoading,
                         error = quotaError,
                         selectedProvider = selectedProvider,
+                        cacheAgeMinutes = cacheAgeMinutes,
                         onRefresh = { viewModel.fetchCodingPlanQuota(force = true) },
                     )
                     // Provider switcher cards - only show if 2+ providers exist
@@ -1020,6 +1031,7 @@ private fun CodingPlanBoard(
     isLoading: Boolean,
     error: String?,
     selectedProvider: String,
+    cacheAgeMinutes: Int, // How old is the cached data (minutes)
     onRefresh: () -> Unit,
 ) {
     Column(
@@ -1035,13 +1047,25 @@ private fun CodingPlanBoard(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             // Title: instance name or default
-            Text(
-                text = if (quota?.instanceName?.isNotBlank() == true) quota.instanceName.uppercase() else stringResource(R.string.repos_coding_plan),
-                fontFamily = JetBrainsMonoFamily,
-                fontWeight = FontWeight.Bold,
-                fontSize = 12.sp,
-                color = Primary,
-            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = if (quota?.instanceName?.isNotBlank() == true) quota.instanceName.uppercase() else stringResource(R.string.repos_coding_plan),
+                    fontFamily = JetBrainsMonoFamily,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 12.sp,
+                    color = Primary,
+                )
+                // Show cache age indicator if data is cached (not fresh)
+                if (cacheAgeMinutes > 0 && !isLoading) {
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Text(
+                        text = "${cacheAgeMinutes}m",
+                        fontFamily = JetBrainsMonoFamily,
+                        fontSize = 9.sp,
+                        color = if (cacheAgeMinutes > 60) TacticalRed else IndustrialOrange,
+                    )
+                }
+            }
             // REFRESH button - prominent color
             if (isLoading) {
                 Text(


### PR DESCRIPTION
## Summary
- Implements WebDAV backend for vault sync (Phase 1 of RFC #3)
- Standard WebDAV protocol support (PROPFIND, MKCOL, PUT, GET, DELETE)
- Works with: 坚果云, Nextcloud, Seafile, OwnCloud, and any WebDAV server
- Optimistic locking with ETag/If-Match for conflict detection
- OkHttp HTTP client with proper Basic Auth authentication

## Changes
- `WebDavBackend.kt` - New file implementing SyncBackend interface
- `build.gradle.kts` - Added OkHttp dependency for HTTP requests

## Technical Details
- Uses OkHttp 4.12.0 for HTTP/WebDAV operations
- Implements all SyncBackend methods: isConfigured, configure, uploadVault, downloadVault, getManifest, deleteSyncData, disconnect
- Additional method `uploadVaultWithLocking` for optimistic locking with ETag
- Credentials stored in SharedPreferences (serverUrl, username, password, basePath)
- Default sync folder: `/lockit-sync/` on WebDAV server

## Test plan
- [x] Build passes (`./gradlew assembleDebug`)
- [ ] Manual testing with 坚果云 WebDAV
- [ ] Manual testing with Nextcloud WebDAV
- [ ] Test conflict detection with ETag

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)