### PR TITLE
fix: WebView OAuth popup support + cookie polling for SPA login

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,8 +29,25 @@
         </activity>
         <activity
             android:name=".ui.screens.auth.WebViewAuthActivity"
-            android:exported="false"
-            android:theme="@style/Theme.Lockit" />
+            android:exported="true"
+            android:launchMode="singleTask"
+            android:theme="@style/Theme.Lockit">
+            <!-- Handle Alipay callback scheme -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <!-- Alipay callback uses this scheme format -->
+                <data android:scheme="alipays" />
+            </intent-filter>
+            <!-- Handle generic HTTPS callbacks from Aliyun -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="account.aliyun.com" />
+            </intent-filter>
+        </activity>
 
         <!-- Coding Plan Widget -->
         <receiver

--- a/app/src/main/java/com/lockit/ui/screens/add_credential/AddCredentialScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/add_credential/AddCredentialScreen.kt
@@ -640,7 +640,14 @@ fun AddCredentialScreen(
 
                                 // For CodingPlan: store all fields as metadata (provider-specific)
                                 val metadata = if (selectedType == CredentialType.CodingPlan) {
-                                    val provider = getField(0)
+                                    val rawProvider = getField(0)
+                                    // Normalize provider key for fetcher registry
+                                    val provider = when (rawProvider) {
+                                        "qwen" -> "qwen_bailian"
+                                        "anthropic" -> "claude"
+                                        "openai" -> "chatgpt"
+                                        else -> rawProvider
+                                    }
                                     val rawCurl = getField(1)
                                     val apiKey = getField(2).takeIf { it.isNotBlank() }
                                         ?: extractApiKeyFromCurl(rawCurl)
@@ -654,15 +661,15 @@ fun AddCredentialScreen(
                                     // Note: cookie field stores user's manual edits for accountId/orgId
                                     // We prioritize manual edits over WebView-extracted data
                                     val prefsData: Map<String, String> = when (provider) {
-                                        "qwen", "qwen_bailian" -> mapOf(
+                                        "qwen_bailian" -> mapOf(
                                             "cookie" to cookie,
                                             "api_key" to (apiKey ?: ""),
                                         )
-                                        "openai", "chatgpt" -> mapOf(
+                                        "chatgpt" -> mapOf(
                                             "accessToken" to (apiKey ?: ""),
                                             "accountId" to (cookie.ifBlank { authExtraData["accountId"] ?: "" }),
                                         )
-                                        "anthropic", "claude" -> mapOf(
+                                        "claude" -> mapOf(
                                             "sessionKey" to (apiKey ?: ""),
                                             "orgId" to (cookie.ifBlank { authExtraData["orgId"] ?: "" }),
                                         )
@@ -679,16 +686,16 @@ fun AddCredentialScreen(
                                         put("provider", provider)
                                         put("baseUrl", baseUrl)
                                         when (provider) {
-                                            "qwen", "qwen_bailian" -> {
+                                            "qwen_bailian" -> {
                                                 put("rawCurl", rawCurl)
                                                 put("apiKey", apiKey)
                                                 put("cookie", cookie)
                                             }
-                                            "openai", "chatgpt" -> {
+                                            "chatgpt" -> {
                                                 put("accessToken", apiKey)
                                                 authExtraData["accountId"]?.let { put("accountId", it) }
                                             }
-                                            "anthropic", "claude" -> {
+                                            "claude" -> {
                                                 put("sessionKey", apiKey)
                                                 authExtraData["orgId"]?.let { put("orgId", it) }
                                             }

--- a/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
+++ b/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
@@ -22,6 +22,7 @@ import com.lockit.ui.components.DraggableFloatingButtons
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
@@ -56,13 +57,19 @@ class WebViewAuthActivity : ComponentActivity() {
         }
     }
 
-    private var webView: WebView? = null
+    internal var webView: WebView? = null
+    internal var authWebViewClient: AuthWebViewClient? = null
+    private var oauthWebChromeClient: OAuthWebChromeClient? = null
     private val scope = CoroutineScope(Dispatchers.Main + Job())
+    private var provider: String = "qwen_bailian"
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val provider = intent.getStringExtra(EXTRA_PROVIDER) ?: "qwen_bailian"
+        provider = intent.getStringExtra(EXTRA_PROVIDER) ?: "qwen_bailian"
+
+        // Handle incoming callback intent from external apps (Alipay, etc.)
+        handleCallbackIntent(intent)
 
         val rootView = FrameLayout(this)
         rootView.setBackgroundColor(android.graphics.Color.WHITE)
@@ -73,10 +80,18 @@ class WebViewAuthActivity : ComponentActivity() {
             settings.loadsImagesAutomatically = true
             settings.mixedContentMode = android.webkit.WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
             settings.userAgentString = "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Mobile Safari/537.36"
+            // Enable popup windows for OAuth login (Google, Microsoft, Apple)
+            settings.setSupportMultipleWindows(true)
+            settings.javaScriptCanOpenWindowsAutomatically = true
             CookieManager.getInstance().setAcceptThirdPartyCookies(this, true)
 
-            webViewClient = AuthWebViewClient(provider, this@WebViewAuthActivity, scope)
-            webChromeClient = object : WebChromeClient() {}
+            val client = AuthWebViewClient(provider, this@WebViewAuthActivity, scope)
+            authWebViewClient = client
+            webViewClient = client
+            // Handle popup windows (OAuth login)
+            val chromeClient = OAuthWebChromeClient(provider, this@WebViewAuthActivity)
+            oauthWebChromeClient = chromeClient
+            webChromeClient = chromeClient
 
             val loginUrl = when (provider) {
                 "qwen_bailian" -> "https://bailian.console.aliyun.com/cn-beijing/?tab=coding-plan#/efm/coding-plan-detail"
@@ -96,7 +111,7 @@ class WebViewAuthActivity : ComponentActivity() {
                 webView?.clearCache(true)
                 webView?.clearHistory()
                 webView?.clearFormData()
-                (webView?.webViewClient as? AuthWebViewClient)?.resetExtractionState()
+                authWebViewClient?.resetExtractionState()
                 val loginUrl = when (provider) {
                     "qwen_bailian" -> "https://bailian.console.aliyun.com/cn-beijing/?tab=coding-plan#/efm/coding-plan-detail"
                     "chatgpt" -> "https://chatgpt.com/auth/login"
@@ -139,10 +154,66 @@ class WebViewAuthActivity : ComponentActivity() {
         setContentView(rootView)
     }
 
+    /**
+     * Handle callback from external apps (Alipay, etc.) after authentication.
+     * Called when activity receives new intent while already running (singleTask).
+     */
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        handleCallbackIntent(intent)
+    }
+
+    /**
+     * Process callback URL from external authentication apps.
+     * Alipay returns via alipays:// scheme with auth result.
+     */
+    private fun handleCallbackIntent(intent: Intent) {
+        val data = intent.data
+        if (data == null) return
+
+        val callbackUrl = data.toString()
+        android.util.Log.d("WebViewAuth", "Received callback: $callbackUrl")
+
+        // Handle Alipay callback - load the result URL in WebView
+        // Alipay typically returns: alipays://platformapi/startapp?appId=20000067&...
+        // or HTTPS callback to account.aliyun.com
+        when {
+            callbackUrl.startsWith("alipays://") -> {
+                // Reset extraction state to allow re-checking login
+                authWebViewClient?.resetExtractionState()
+                // Reload the original login page to check if auth succeeded
+                webView?.reload()
+                android.widget.Toast.makeText(this, "支付宝认证完成，正在验证...", android.widget.Toast.LENGTH_SHORT).show()
+            }
+            callbackUrl.contains("account.aliyun.com") || callbackUrl.contains("console.aliyun.com") -> {
+                // Direct HTTPS callback - load in WebView
+                authWebViewClient?.resetExtractionState()
+                webView?.loadUrl(callbackUrl)
+            }
+        }
+    }
+
+    /**
+     * When user returns from external app, trigger WebView to check login status.
+     * Only reset if not already extracted (prevents duplicate extraction).
+     */
+    override fun onResume() {
+        super.onResume()
+        // Trigger WebView reload to check if external auth succeeded
+        // The WebViewClient will check cookies and extract if login is complete
+        if (authWebViewClient?.hasExtracted() == false) {
+            webView?.reload()
+        }
+    }
+
     override fun onDestroy() {
         scope.coroutineContext[Job]?.cancel()
+        oauthWebChromeClient?.cleanupAll()
+        oauthWebChromeClient = null
         webView?.destroy()
         webView = null
+        authWebViewClient = null
         super.onDestroy()
     }
 }
@@ -158,40 +229,125 @@ class AuthWebViewClient(
 ) : WebViewClient() {
 
     private var hasExtracted = false
+    private var cookieCheckJob: kotlinx.coroutines.Job? = null
 
     fun resetExtractionState() {
         hasExtracted = false
+        cookieCheckJob?.cancel()
+        cookieCheckJob = null
     }
+
+    fun hasExtracted(): Boolean = hasExtracted
 
     override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
         super.onPageStarted(view, url, favicon)
-        // Reset extraction state on any page navigation (allows retry for all providers)
         hasExtracted = false
+        cookieCheckJob?.cancel()
+        android.util.Log.d("WebViewAuth", "Page started: $url")
+    }
+
+    /**
+     * Handle network errors (timeout, connection failed, etc.)
+     */
+    override fun onReceivedError(view: WebView?, request: WebResourceRequest?, error: android.webkit.WebResourceError?) {
+        super.onReceivedError(view, request, error)
+        val url = request?.url?.toString() ?: ""
+        val errorCode = error?.errorCode ?: -1
+        val description = error?.description ?: "Unknown error"
+
+        android.util.Log.e("WebViewAuth", "Error loading $url: $errorCode - $description")
+
+        // Only show error for main page load (not subresources)
+        if (request?.isForMainFrame == true) {
+            val errorMessage = when (errorCode) {
+                android.webkit.WebViewClient.ERROR_TIMEOUT -> "加载超时 - ChatGPT/Claude 需要代理，请确保系统 VPN 已开启"
+                android.webkit.WebViewClient.ERROR_CONNECT -> "无法连接服务器 - 请检查网络或 VPN"
+                android.webkit.WebViewClient.ERROR_HOST_LOOKUP -> "无法解析域名 - 请检查网络连接"
+                -1 -> "网络错误: $description"
+                else -> "加载失败 ($errorCode)"
+            }
+            android.widget.Toast.makeText(activity, errorMessage, android.widget.Toast.LENGTH_LONG).show()
+        }
     }
 
     override fun onPageFinished(view: WebView?, url: String?) {
         super.onPageFinished(view, url)
+        android.util.Log.d("WebViewAuth", "Page finished: $url")
 
         if (hasExtracted) return
 
-        // Check if user has actually logged in by verifying cookies exist
+        // For SPA (Claude/ChatGPT), start polling for cookies
+        // because onPageFinished may fire before auth state updates
+        if (provider == "claude" || provider == "chatgpt") {
+            startCookiePolling(view)
+        } else {
+            checkLoginAndExtract(view, url)
+        }
+    }
+
+    /**
+     * Poll cookies every 2 seconds for SPA login detection.
+     * Claude/ChatGPT are SPA - onPageFinished fires before auth state updates.
+     */
+    private fun startCookiePolling(view: WebView?) {
+        cookieCheckJob?.cancel()
+        cookieCheckJob = scope.launch {
+            var attempts = 0
+            val maxAttempts = 30 // 60 seconds max
+
+            while (!hasExtracted && attempts < maxAttempts) {
+                kotlinx.coroutines.delay(2000)
+                attempts++
+
+                // Get cookies from the WebView's current URL
+                val currentUrl = view?.url ?: "https://claude.ai"
+                val cookieManager = CookieManager.getInstance()
+                val cookies = cookieManager.getCookie(currentUrl) ?: ""
+
+                android.util.Log.d("WebViewAuth", "Cookie poll attempt $attempts for $provider: ${cookies.take(100)}...")
+
+                // Check login status based on provider
+                val isLoggedIn = when (provider) {
+                    "claude" -> {
+                        // Claude uses sessionKey cookie after login
+                        cookies.contains("sessionKey=")
+                    }
+                    "chatgpt" -> {
+                        // ChatGPT: check if we're on the main page (not auth) and have session cookies
+                        // After login, URL becomes chatgpt.com (no /auth) and has cookies like __Secure-next-auth.session-token
+                        !currentUrl.contains("/auth") &&
+                        cookies.contains("__Secure-") || cookies.contains("session")
+                    }
+                    else -> false
+                }
+
+                if (isLoggedIn) {
+                    hasExtracted = true
+                    android.util.Log.d("WebViewAuth", "Login detected after $attempts polls!")
+                    extractCredentials(view, currentUrl)
+                    break
+                }
+            }
+
+            if (!hasExtracted && attempts >= maxAttempts) {
+                android.widget.Toast.makeText(
+                    activity,
+                    "登录检测超时，请刷新页面重试",
+                    android.widget.Toast.LENGTH_LONG
+                ).show()
+            }
+        }
+    }
+
+    private fun checkLoginAndExtract(view: WebView?, url: String?) {
         val cookieManager = CookieManager.getInstance()
         val cookies = cookieManager.getCookie(url ?: "") ?: ""
 
         val isLoggedIn = when (provider) {
-            // Bailian: must have login_aliyunid_ticket (full login session)
             "qwen_bailian" -> {
                 url?.contains("console.aliyun.com") == true &&
                 cookies.contains("login_aliyunid_ticket")
             }
-            // ChatGPT: logged in when URL is main page (not auth path) and has cookies
-            "chatgpt" -> url?.contains("chatgpt.com") == true &&
-                         !url.contains("/auth") &&
-                         cookies.isNotBlank()
-            // Claude: logged in when sessionKey cookie exists
-            "claude" -> url?.contains("claude.ai") == true &&
-                        !url.contains("/login") &&
-                        cookies.contains("sessionKey")
             else -> false
         }
 
@@ -203,6 +359,21 @@ class AuthWebViewClient(
 
     override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
         val url = request?.url?.toString() ?: return false
+
+        // OAuth providers - must load in WebView (not external app)
+        // These are HTTPS redirects, not app schemes
+        val oauthDomains = listOf(
+            "accounts.google.com",
+            "login.microsoftonline.com",
+            "appleid.apple.com",
+            "auth.openai.com",
+        )
+        val isOAuthRedirect = oauthDomains.any { domain -> url.contains(domain) }
+        if (isOAuthRedirect) {
+            // Let WebView load OAuth page internally
+            android.util.Log.d("WebViewAuth", "OAuth redirect: $url")
+            return false  // Continue loading in WebView
+        }
 
         // Handle external app schemes (Alipay, Taobao, DingTalk, Tmall, WeChat, SMS, Tel)
         if (url.startsWith("alipay://") ||
@@ -241,6 +412,7 @@ class AuthWebViewClient(
             }
         }
 
+        // All other URLs load in WebView
         return false
     }
 
@@ -309,5 +481,123 @@ class AuthWebViewClient(
     private fun returnFailed(message: String) {
         activity.setResult(WebViewAuthActivity.RESULT_FAILED)
         activity.finish()
+    }
+}
+
+/**
+ * Simple WebViewClient for OAuth popup windows.
+ * Does NOT attempt credential extraction - popups are just for OAuth login.
+ * The main WebView handles credential extraction after OAuth completes.
+ */
+class OAuthPopupWebViewClient(
+    private val activity: WebViewAuthActivity,
+) : WebViewClient() {
+
+    override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
+        val url = request?.url?.toString() ?: return false
+
+        // Handle external app schemes from OAuth popups (rare but possible)
+        if (url.startsWith("alipay://") ||
+            url.startsWith("alipays://") ||
+            url.startsWith("weixin://") ||
+            url.startsWith("sms:") ||
+            url.startsWith("tel:")) {
+            try {
+                val intent = Intent(Intent.ACTION_VIEW, android.net.Uri.parse(url))
+                activity.startActivity(intent)
+                return true
+            } catch (e: android.content.ActivityNotFoundException) {
+                return false
+            }
+        }
+
+        // All other URLs load in the popup WebView
+        return false
+    }
+
+    override fun onPageFinished(view: WebView?, url: String?) {
+        super.onPageFinished(view, url)
+        android.util.Log.d("OAuthPopup", "Popup page finished: $url")
+        // Do NOT extract credentials - this is just an OAuth popup
+    }
+}
+
+/**
+ * WebChromeClient that handles popup windows for OAuth login.
+ * Google/Microsoft/Apple OAuth may open new windows for authentication.
+ */
+class OAuthWebChromeClient(
+    private val provider: String,
+    private val activity: WebViewAuthActivity,
+) : WebChromeClient() {
+
+    // Track popup WebViews for cleanup
+    private val popupWebViews = mutableListOf<WebView>()
+
+    override fun onCreateWindow(
+        view: WebView?,
+        isDialog: Boolean,
+        isUserGesture: Boolean,
+        resultMsg: android.os.Message?
+    ): Boolean {
+        android.util.Log.d("OAuthWebChrome", "onCreateWindow: isDialog=$isDialog, isUserGesture=$isUserGesture")
+
+        // Validate resultMsg before proceeding
+        if (resultMsg == null) {
+            android.util.Log.e("OAuthWebChrome", "resultMsg is null, cannot create popup")
+            return false
+        }
+
+        // Create a new WebView for the popup
+        val popupWebView = WebView(activity)
+        popupWebView.settings.javaScriptEnabled = true
+        popupWebView.settings.domStorageEnabled = true
+        // Popups should NOT create more popups to avoid infinite loops
+        popupWebView.settings.setSupportMultipleWindows(false)
+        popupWebView.settings.javaScriptCanOpenWindowsAutomatically = false
+
+        // Use simple client that does NOT extract credentials - popups are just for OAuth
+        popupWebView.webViewClient = OAuthPopupWebViewClient(activity)
+
+        // Track WebView for cleanup
+        popupWebViews.add(popupWebView)
+
+        // Configure the WebView to load in the popup
+        val transport = resultMsg.obj as? android.webkit.WebView.WebViewTransport
+        if (transport != null) {
+            transport.webView = popupWebView
+            resultMsg.sendToTarget()
+            return true
+        } else {
+            android.util.Log.e("OAuthWebChrome", "Transport cast failed, cleaning up")
+            cleanupPopup(popupWebView)
+            return false
+        }
+    }
+
+    override fun onCloseWindow(window: WebView?) {
+        android.util.Log.d("OAuthWebChrome", "onCloseWindow")
+        // Find and cleanup the closed popup
+        val index = popupWebViews.indexOf(window)
+        if (index >= 0) {
+            cleanupPopup(popupWebViews[index])
+            popupWebViews.removeAt(index)
+        }
+        // When popup closes, trigger main WebView to check login status
+        activity.authWebViewClient?.resetExtractionState()
+        activity.webView?.reload()
+        super.onCloseWindow(window)
+    }
+
+    private fun cleanupPopup(webView: WebView?) {
+        webView?.destroy()
+    }
+
+    /**
+     * Cleanup all popups when activity destroys.
+     */
+    fun cleanupAll() {
+        popupWebViews.forEach { it.destroy() }
+        popupWebViews.clear()
     }
 }

--- a/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
+++ b/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
@@ -68,9 +68,6 @@ class WebViewAuthActivity : ComponentActivity() {
 
         provider = intent.getStringExtra(EXTRA_PROVIDER) ?: "qwen_bailian"
 
-        // Handle incoming callback intent from external apps (Alipay, etc.)
-        handleCallbackIntent(intent)
-
         val rootView = FrameLayout(this)
         rootView.setBackgroundColor(android.graphics.Color.WHITE)
 
@@ -101,6 +98,10 @@ class WebViewAuthActivity : ComponentActivity() {
             }
             loadUrl(loginUrl)
         }
+
+        // Handle incoming callback intent from external apps (Alipay, etc.)
+        // Called AFTER webView initialization to avoid NPE
+        handleCallbackIntent(intent)
 
         // Glassmorphism floating buttons - draggable overlay
         val floatingButtons = DraggableFloatingButtons(
@@ -301,7 +302,13 @@ class AuthWebViewClient(
                 attempts++
 
                 // Get cookies from the WebView's current URL
-                val currentUrl = view?.url ?: "https://claude.ai"
+                // Use provider-specific fallback URL
+                val fallbackUrl = when (provider) {
+                    "chatgpt" -> "https://chatgpt.com"
+                    "claude" -> "https://claude.ai"
+                    else -> "https://claude.ai"
+                }
+                val currentUrl = view?.url ?: fallbackUrl
                 val cookieManager = CookieManager.getInstance()
                 val cookies = cookieManager.getCookie(currentUrl) ?: ""
 
@@ -314,10 +321,10 @@ class AuthWebViewClient(
                         cookies.contains("sessionKey=")
                     }
                     "chatgpt" -> {
-                        // ChatGPT: check if we're on the main page (not auth) and have session cookies
-                        // After login, URL becomes chatgpt.com (no /auth) and has cookies like __Secure-next-auth.session-token
+                        // ChatGPT: check if we're on the main page (not auth) AND have session cookies
+                        // Fix: && has higher precedence than ||, need parentheses
                         !currentUrl.contains("/auth") &&
-                        cookies.contains("__Secure-") || cookies.contains("session")
+                        (cookies.contains("__Secure-") || cookies.contains("session"))
                     }
                     else -> false
                 }
@@ -577,6 +584,7 @@ class OAuthWebChromeClient(
         } else {
             android.util.Log.e("OAuthWebChrome", "Transport cast failed, cleaning up")
             dialog.dismiss()
+            popupWebView.destroy()  // Prevent WebView leak
             return false
         }
     }
@@ -593,15 +601,15 @@ class OAuthWebChromeClient(
         activity.webView?.reload()
     }
 
-    private fun cleanupPopup(webView: WebView?) {
-        webView?.destroy()
-    }
-
     /**
      * Cleanup all popups when activity destroys.
+     * Dismiss dialogs and destroy WebViews to prevent memory/window leaks.
      */
     fun cleanupAll() {
-        popupWebViews.forEach { it.destroy() }
+        popupWebViews.forEach { webView ->
+            (webView.tag as? android.app.Dialog)?.dismiss()
+            webView.destroy()
+        }
         popupWebViews.clear()
     }
 }

--- a/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
+++ b/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
@@ -186,10 +186,14 @@ class WebViewAuthActivity : ComponentActivity() {
                 webView?.reload()
                 android.widget.Toast.makeText(this, "支付宝认证完成，正在验证...", android.widget.Toast.LENGTH_SHORT).show()
             }
-            callbackUrl.contains("account.aliyun.com") || callbackUrl.contains("console.aliyun.com") -> {
-                // Direct HTTPS callback - load in WebView
-                authWebViewClient?.resetExtractionState()
-                webView?.loadUrl(callbackUrl)
+            else -> {
+                // Security: Use strict host validation, not contains() which can be bypassed
+                val host = data.host
+                if (host == "account.aliyun.com" || host == "console.aliyun.com") {
+                    // Direct HTTPS callback - load in WebView
+                    authWebViewClient?.resetExtractionState()
+                    webView?.loadUrl(callbackUrl)
+                }
             }
         }
     }
@@ -200,11 +204,8 @@ class WebViewAuthActivity : ComponentActivity() {
      */
     override fun onResume() {
         super.onResume()
-        // Trigger WebView reload to check if external auth succeeded
-        // The WebViewClient will check cookies and extract if login is complete
-        if (authWebViewClient?.hasExtracted() == false) {
-            webView?.reload()
-        }
+        // Removed: unconditional reload disrupts UX when user returns from password manager
+        // onNewIntent already handles deep link callbacks from external apps
     }
 
     override fun onDestroy() {
@@ -304,7 +305,7 @@ class AuthWebViewClient(
                 val cookieManager = CookieManager.getInstance()
                 val cookies = cookieManager.getCookie(currentUrl) ?: ""
 
-                android.util.Log.d("WebViewAuth", "Cookie poll attempt $attempts for $provider: ${cookies.take(100)}...")
+                android.util.Log.d("WebViewAuth", "Cookie poll attempt $attempts for $provider")
 
                 // Check login status based on provider
                 val isLoggedIn = when (provider) {
@@ -549,44 +550,47 @@ class OAuthWebChromeClient(
         }
 
         // Create a new WebView for the popup
-        val popupWebView = WebView(activity)
-        popupWebView.settings.javaScriptEnabled = true
-        popupWebView.settings.domStorageEnabled = true
-        // Popups should NOT create more popups to avoid infinite loops
-        popupWebView.settings.setSupportMultipleWindows(false)
-        popupWebView.settings.javaScriptCanOpenWindowsAutomatically = false
+        val popupWebView = WebView(activity).apply {
+            settings.javaScriptEnabled = true
+            settings.domStorageEnabled = true
+            // Popups should NOT create more popups to avoid infinite loops
+            settings.setSupportMultipleWindows(false)
+            settings.javaScriptCanOpenWindowsAutomatically = false
+            // Use simple client that does NOT extract credentials - popups are just for OAuth
+            webViewClient = OAuthPopupWebViewClient(activity)
+        }
 
-        // Use simple client that does NOT extract credentials - popups are just for OAuth
-        popupWebView.webViewClient = OAuthPopupWebViewClient(activity)
-
-        // Track WebView for cleanup
-        popupWebViews.add(popupWebView)
+        // Show the popup in a fullscreen dialog so the user can interact with it
+        val dialog = android.app.Dialog(activity, android.R.style.Theme_NoTitleBar_Fullscreen)
+        dialog.setContentView(popupWebView)
+        dialog.show()
+        // Store dialog reference for cleanup
+        popupWebView.tag = dialog
 
         // Configure the WebView to load in the popup
         val transport = resultMsg.obj as? android.webkit.WebView.WebViewTransport
         if (transport != null) {
             transport.webView = popupWebView
             resultMsg.sendToTarget()
+            popupWebViews.add(popupWebView)
             return true
         } else {
             android.util.Log.e("OAuthWebChrome", "Transport cast failed, cleaning up")
-            cleanupPopup(popupWebView)
+            dialog.dismiss()
             return false
         }
     }
 
     override fun onCloseWindow(window: WebView?) {
         android.util.Log.d("OAuthWebChrome", "onCloseWindow")
-        // Find and cleanup the closed popup
-        val index = popupWebViews.indexOf(window)
-        if (index >= 0) {
-            cleanupPopup(popupWebViews[index])
-            popupWebViews.removeAt(index)
-        }
+        // Dismiss the dialog to prevent window leaks
+        (window?.tag as? android.app.Dialog)?.dismiss()
+        popupWebViews.remove(window)
+        window?.destroy()
+
         // When popup closes, trigger main WebView to check login status
         activity.authWebViewClient?.resetExtractionState()
         activity.webView?.reload()
-        super.onCloseWindow(window)
     }
 
     private fun cleanupPopup(webView: WebView?) {

--- a/app/src/main/java/com/lockit/ui/screens/edit_credential/EditCredentialScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/edit_credential/EditCredentialScreen.kt
@@ -480,8 +480,16 @@ private fun EditCredentialForm(
                                     metadata = if (selectedType == CredentialType.CodingPlan) {
                                         val cookie = getField(3).takeIf { it.isNotBlank() }
                                             ?: extractCookieFromCurl(getField(1))
+                                        val rawProvider = getField(0)
+                                        // Normalize provider key for fetcher registry
+                                        val provider = when (rawProvider) {
+                                            "qwen" -> "qwen_bailian"
+                                            "anthropic" -> "claude"
+                                            "openai" -> "chatgpt"
+                                            else -> rawProvider
+                                        }
                                         JSONObject().apply {
-                                            put("provider", getField(0))
+                                            put("provider", provider)
                                             put("rawCurl", getField(1))
                                             put("apiKey", getField(2))
                                             put("cookie", cookie)


### PR DESCRIPTION
## Summary
- Add OAuthWebChromeClient for popup window handling (Google/Microsoft OAuth login)
- Implement cookie polling for Claude/ChatGPT SPA login detection
- Handle external app schemes (Alipay, WeChat) with proper intent filters
- Add Alipay callback scheme (`alipays://`) in AndroidManifest
- Normalize provider keys in credential forms (qwen→qwen_bailian, anthropic→claude, openai→chatgpt)
- Improve error handling with VPN hints for timeout errors

## Changes
- `WebViewAuthActivity.kt` — OAuth popup support, cookie polling, external scheme handling
- `AndroidManifest.xml` — Alipay callback intent filter, singleTask launch mode
- `AddCredentialScreen.kt` / `EditCredentialScreen.kt` — Provider key normalization

## Test plan
- [x] Build passes (`./gradlew assembleDebug`)
- [ ] Manual test: ChatGPT Google login via WebView
- [ ] Manual test: Claude login via WebView
- [ ] Manual test: Qwen Bailian Alipay login

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)