### PR TITLE
enhance: add COPY button to credential cards

### DIFF
--- a/app/src/main/java/com/lockit/ui/components/CredentialCard.kt
+++ b/app/src/main/java/com/lockit/ui/components/CredentialCard.kt
@@ -285,12 +285,25 @@ fun CredentialCard(
 
         Spacer(modifier = Modifier.height(8.dp))
 
-        // Action buttons
+        // Action buttons - COPY added for UX improvement
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             BrutalistButton(
                 text = "DELETE",
                 onClick = { showDeleteDialog = true },
                 variant = ButtonVariant.Danger,
+                modifier = Modifier.weight(1f).height(32.dp),
+                useMonoFont = true,
+            )
+            BrutalistButton(
+                text = "COPY",
+                onClick = {
+                    if (localRevealed || alwaysVisible) {
+                        onCopy(CopyAction.STRUCTURED)
+                    } else {
+                        onNeedReveal()
+                    }
+                },
+                variant = ButtonVariant.Secondary,
                 modifier = Modifier.weight(1f).height(32.dp),
                 useMonoFont = true,
             )


### PR DESCRIPTION
## Summary
- Add explicit COPY button to credential card action row (DELETE | COPY | EDIT)
- Improves UX discoverability - users don't need to discover hidden long-press
- COPY respects biometric verification requirements

## Changes
- Added COPY button between DELETE and EDIT in CredentialCard.kt
- COPY triggers onNeedReveal for sensitive types if not revealed
- For alwaysVisible types (Phone/IdCard/Note), copies directly

## UX Improvement
| Before | After |
|--------|-------|
| Hidden long-press gesture | Visible COPY button |
| Users don't know how to copy | Obvious action button |
| 2-step reveal + long-press | Single COPY click (verifies if needed) |

## Test plan
- [x] Build passes (`./gradlew assembleDebug lintDebug`)
- [ ] Manual test: COPY button visible on all credential types
- [ ] Manual test: COPY on Email/Account triggers biometric if not revealed
- [ ] Manual test: COPY on Phone/IdCard/Note copies directly

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)