### PR TITLE
enhance: add API level check for device credential fallback

### DIFF
--- a/app/src/main/java/com/lockit/utils/BiometricUtils.kt
+++ b/app/src/main/java/com/lockit/utils/BiometricUtils.kt
@@ -1,5 +1,6 @@
 package com.lockit.utils
 
+import android.os.Build
 import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricPrompt
 import androidx.core.content.ContextCompat
@@ -55,10 +56,13 @@ object BiometricUtils {
 
     fun canAuthenticate(activity: FragmentActivity): Boolean {
         val biometricManager = BiometricManager.from(activity)
-        return biometricManager.canAuthenticate(
+        // DEVICE_CREDENTIAL requires API 30+, fall back to BIOMETRIC_STRONG only on older devices
+        val authenticators = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            BiometricManager.Authenticators.BIOMETRIC_STRONG or BiometricManager.Authenticators.DEVICE_CREDENTIAL
+        } else {
             BiometricManager.Authenticators.BIOMETRIC_STRONG
-                or BiometricManager.Authenticators.DEVICE_CREDENTIAL
-        ) == BiometricManager.BIOMETRIC_SUCCESS
+        }
+        return biometricManager.canAuthenticate(authenticators) == BiometricManager.BIOMETRIC_SUCCESS
     }
 
     /**
@@ -101,10 +105,20 @@ object BiometricUtils {
         val promptInfo = BiometricPrompt.PromptInfo.Builder()
             .setTitle(title)
             .setSubtitle(subtitle)
-            .setAllowedAuthenticators(
-                BiometricManager.Authenticators.BIOMETRIC_STRONG
-                    or BiometricManager.Authenticators.DEVICE_CREDENTIAL
-            )
+            .apply {
+                // DEVICE_CREDENTIAL requires API 30+ (Android R)
+                // On API 30+: allow device credential fallback, no negative button needed (system handles)
+                // On API < 30: only BIOMETRIC_STRONG, cannot use device credential
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    setAllowedAuthenticators(
+                        BiometricManager.Authenticators.BIOMETRIC_STRONG or
+                        BiometricManager.Authenticators.DEVICE_CREDENTIAL
+                    )
+                } else {
+                    setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG)
+                    setNegativeButtonText("取消")
+                }
+            }
             .build()
 
         biometricPrompt.authenticate(promptInfo)


### PR DESCRIPTION
## Summary
- Add API level check for DEVICE_CREDENTIAL support in BiometricUtils
- Fixes potential crash/failure on devices below API 30

## Changes
- `BiometricUtils.kt`: Added Build.VERSION.SDK_INT check
- API 30+: Allow BIOMETRIC_STRONG + DEVICE_CREDENTIAL
- API < 30: Fall back to BIOMETRIC_STRONG only + "取消" negative button

## Technical Notes
DEVICE_CREDENTIAL was introduced in API 30 (Android R). Using it on older devices causes authentication to fail. BiometricPinStorage.kt already had this check; this PR aligns BiometricUtils.kt with the same pattern.

## Test plan
- [x] Build passes (`./gradlew assembleDebug lintDebug`)
- [ ] Manual test on API 30+ device: verify device password fallback appears
- [ ] Manual test on API < 30 device: verify biometric-only with cancel button

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)