### PR TITLE
fix: use dynamic node ID from Android ID instead of hardcoded LX-88

### DIFF
--- a/app/src/main/java/com/lockit/ui/screens/vault_unlock/VaultUnlockScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/vault_unlock/VaultUnlockScreen.kt
@@ -1,5 +1,6 @@
 package com.lockit.ui.screens.vault_unlock
 
+import android.provider.Settings
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -69,6 +70,9 @@ class VaultUnlockViewModel(private val app: LockitApp) : ViewModel() {
     private val biometricStorage = com.lockit.data.biometric.BiometricPinStorage(
         app.getSharedPreferences("lockit_biometric_prefs", android.content.Context.MODE_PRIVATE)
     )
+
+    // Node ID - generated from Android ID, persisted in SharedPreferences
+    val nodeId: String = getOrCreateNodeId(app)
 
     private val _uiState = MutableStateFlow(VaultUnlockUiState())
     val uiState: StateFlow<VaultUnlockUiState> = _uiState.asStateFlow()
@@ -257,6 +261,23 @@ class VaultUnlockViewModel(private val app: LockitApp) : ViewModel() {
 data class VaultUnlockUiState(
     val navigated: Boolean = false,
 )
+
+/**
+ * Generate or retrieve node ID from Android ID.
+ * First generation is persisted in SharedPreferences for consistency.
+ */
+private fun getOrCreateNodeId(app: LockitApp): String {
+    val prefs = app.getSharedPreferences("lockit_device", android.content.Context.MODE_PRIVATE)
+    val existing = prefs.getString("node_id", null)
+    if (existing != null) return existing
+
+    val androidId = Settings.Secure.getString(
+        app.contentResolver, Settings.Secure.ANDROID_ID
+    ) ?: "000000"
+    val newNodeId = "LX-${androidId.take(6).uppercase()}"
+    prefs.edit().putString("node_id", newNodeId).apply()
+    return newNodeId
+}
 
 @Composable
 fun VaultUnlockScreen(
@@ -612,11 +633,11 @@ fun VaultUnlockScreen(
                 )
             }
             Text(
-                text = stringResource(R.string.vault_node_id),
-                fontFamily = JetBrainsMonoFamily,
-                fontSize = 9.sp,
-                color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.4f),
-            )
+                    text = stringResource(R.string.vault_node_id_label, viewModel.nodeId),
+                    fontFamily = JetBrainsMonoFamily,
+                    fontSize = 9.sp,
+                    color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.4f),
+                )
         }
     }
     }

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -28,7 +28,7 @@
     <string name="vault_enable">启用</string>
     <string name="vault_enc_link">加密链: 活动</string>
     <string name="vault_os_ver">系统版本: 4.1.0_锁定</string>
-    <string name="vault_node_id">节点ID: LX-88</string>
+    <string name="vault_node_id_label">节点ID: %s</string>
 
     <!-- Error Messages -->
     <string name="error_pin_too_short">PIN太短</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,7 +28,7 @@
     <string name="vault_enable">ENABLE</string>
     <string name="vault_enc_link">ENC_LINK: ACTIVE</string>
     <string name="vault_os_ver">OS_VER: 4.1.0_LOCKED</string>
-    <string name="vault_node_id">NODE_ID: LX-88</string>
+    <string name="vault_node_id_label">NODE_ID: %s</string>
 
     <!-- Error Messages -->
     <string name="error_pin_too_short">PIN_TOO_SHORT</string>


### PR DESCRIPTION
## Summary
- Replace hardcoded node ID "LX-88" with dynamic value generated from Android ID
- Each device now shows unique node ID based on ANDROID_ID

## Changes
- Add `getOrCreateNodeId()` function using `Settings.Secure.ANDROID_ID`
- Add `nodeId` property to `VaultUnlockViewModel`
- Update strings.xml to use format placeholder (`%s`)
- Update VaultUnlockScreen.kt to display dynamic nodeId via ViewModel

## Implementation
Node ID format: `LX-{ANDROID_ID_6CHARS}`
Example: If ANDROID_ID is `a1b2c3d4e5f6`, node ID will be `LX-A1B2C3`

The value is persisted in SharedPreferences on first generation for consistency.

## Test plan
- [x] Build passes
- [ ] Verify each device shows different node ID
- [ ] Verify node ID persists after app restart

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)