### PR TITLE
fix: put recovery and biometric buttons on same row

### DIFF
--- a/app/src/main/java/com/lockit/ui/screens/vault_unlock/VaultUnlockScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/vault_unlock/VaultUnlockScreen.kt
@@ -465,7 +465,6 @@ fun VaultUnlockScreen(
                                                 }
                                             },
                                             icon = Icons.Default.Fingerprint,
-                                            iconColor = White,
                                             modifier = Modifier.weight(1f),
                                         )
                                     } else {
@@ -804,7 +803,7 @@ private fun BrutalistSmallButton(
     modifier: Modifier = Modifier,
     isDanger: Boolean = false,
     icon: androidx.compose.ui.graphics.vector.ImageVector? = null,
-    iconColor: Color = Primary,
+    iconColor: Color = if (isDanger) White else Primary,  // Match text color based on danger state
 ) {
     Row(
         modifier = modifier

--- a/app/src/main/java/com/lockit/ui/screens/vault_unlock/VaultUnlockScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/vault_unlock/VaultUnlockScreen.kt
@@ -440,42 +440,37 @@ fun VaultUnlockScreen(
                                     )
                                 }
                             } else {
-                                if (viewModel.isInitialized && viewModel.isBiometricLinked) {
-                                    // Only show biometric button if biometric is linked
-                                    // "Link biometric" moved to Settings page
-                                    val unlockTitle = stringResource(R.string.biometric_unlock_title)
-                                    val unlockSubtitle = stringResource(R.string.biometric_unlock_subtitle)
-                                    BrutalistActionButton(
-                                        text = stringResource(R.string.vault_unlock_biometric),
-                                        onClick = {
-                                            val activity = view.findActivity()
-                                            if (activity != null) {
-                                                viewModel.authenticateWithBiometric(
-                                                    activity = activity,
-                                                    title = unlockTitle,
-                                                    subtitle = unlockSubtitle,
-                                                    onSuccess = { },
-                                                    onError = { viewModel.errorMessage = "BIOMETRIC_FAILED: $it" },
-                                                )
-                                            }
-                                        },
-                                        icon = Icons.Default.Fingerprint,
-                                        iconColor = White,
-                                    )
-                                    Spacer(modifier = Modifier.height(8.dp))
-                                }
+                                // Bottom row: Recovery + Biometric (if linked)
                                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                                     BrutalistSmallButton(
                                         text = stringResource(R.string.vault_recover_id),
                                         onClick = { /* Post-MVP: account recovery flow */ },
                                         modifier = Modifier.weight(1f),
                                     )
-                                    BrutalistSmallButton(
-                                        text = stringResource(R.string.vault_emergency_sos),
-                                        onClick = { /* Post-MVP: emergency access protocol */ },
-                                        modifier = Modifier.weight(1f),
-                                        isDanger = true,
-                                    )
+                                    if (viewModel.isInitialized && viewModel.isBiometricLinked) {
+                                        val unlockTitle = stringResource(R.string.biometric_unlock_title)
+                                        val unlockSubtitle = stringResource(R.string.biometric_unlock_subtitle)
+                                        BrutalistSmallButton(
+                                            text = stringResource(R.string.vault_unlock_biometric),
+                                            onClick = {
+                                                val activity = view.findActivity()
+                                                if (activity != null) {
+                                                    viewModel.authenticateWithBiometric(
+                                                        activity = activity,
+                                                        title = unlockTitle,
+                                                        subtitle = unlockSubtitle,
+                                                        onSuccess = { },
+                                                        onError = { viewModel.errorMessage = "BIOMETRIC_FAILED: $it" },
+                                                    )
+                                                }
+                                            },
+                                            icon = Icons.Default.Fingerprint,
+                                            iconColor = White,
+                                            modifier = Modifier.weight(1f),
+                                        )
+                                    } else {
+                                        Spacer(modifier = Modifier.weight(1f))
+                                    }
                                 }
                             }
                         }
@@ -808,15 +803,27 @@ private fun BrutalistSmallButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     isDanger: Boolean = false,
+    icon: androidx.compose.ui.graphics.vector.ImageVector? = null,
+    iconColor: Color = Primary,
 ) {
-    Box(
+    Row(
         modifier = modifier
             .height(32.dp)
             .border(1.dp, if (isDanger) TacticalRed else Primary)
             .clickable(onClick = onClick)
             .background(if (isDanger) TacticalRed else White),
-        contentAlignment = Alignment.Center,
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
     ) {
+        if (icon != null) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = iconColor,
+                modifier = Modifier.size(14.dp),
+            )
+            Spacer(modifier = Modifier.width(4.dp))
+        }
         Text(
             text = text,
             fontFamily = JetBrainsMonoFamily,


### PR DESCRIPTION
## Summary
- Replace two-row layout with single-row layout for vault unlock buttons
- Remove emergency SOS button (Post-MVP feature)
- Add icon support to BrutalistSmallButton

## Changes

**Layout change:**
Before:
```
[     指纹按钮（全宽）      ]
[恢复ID]     [紧急求助]
```

After:
```
[ 恢复ID ]  [ 指纹解锁 ]
```

**Code changes:**
- Add icon and iconColor parameters to BrutalistSmallButton
- Put biometric and recovery buttons in same Row with weight(1f)
- Remove emergency SOS button (not implemented)
- Add Spacer when biometric not linked for symmetry

## Test plan
- [x] Build passes
- [ ] Verify buttons are on same row
- [ ] Verify biometric button shows fingerprint icon
- [ ] Verify layout is correct when biometric not linked

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)