### PR TITLE
feat: add WebDAV sync configuration UI

### DIFF
--- a/app/src/main/java/com/lockit/data/sync/WebDavBackend.kt
+++ b/app/src/main/java/com/lockit/data/sync/WebDavBackend.kt
@@ -408,6 +408,20 @@ class WebDavBackend(private val context: Context) : SyncBackend {
         Log.i(TAG, "WebDAV disconnected")
     }
 
+    /**
+     * Clear configuration (alias for disconnect, callable from UI).
+     */
+    fun clearConfig() {
+        prefs.edit().clear().apply()
+        synchronized(this) {
+            client = null
+            serverUrl = null
+            username = null
+            password = null
+            basePath = null
+        }
+    }
+
     private fun loadCredentials() {
         synchronized(this) {
             if (serverUrl == null) {

--- a/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
@@ -163,6 +163,7 @@ fun ConfigScreen(
     // WebDAV sync
     val webDavBackend = remember { WebDavBackend(context) }
     var webDavConfigured by remember { mutableStateOf(false) }
+    var webDavConfiguring by remember { mutableStateOf(false) }
     var showWebDavDialog by remember { mutableStateOf(false) }
     var webDavServerUrl by remember { mutableStateOf("") }
     var webDavUsername by remember { mutableStateOf("") }
@@ -588,6 +589,11 @@ fun ConfigScreen(
                                     // Clear WebDAV configuration
                                     webDavBackend.clearConfig()
                                     webDavConfigured = false
+                                    // Reset sensitive UI state variables
+                                    webDavPassword = ""
+                                    webDavServerUrl = ""
+                                    webDavUsername = ""
+                                    webDavBasePath = "/lockit-sync"
                                     toastMessage = context.getString(R.string.toast_signed_out)
                                 },
                                 variant = ButtonVariant.Warning,
@@ -659,6 +665,8 @@ fun ConfigScreen(
                             BrutalistButton(
                                 text = stringResource(R.string.config_webdav_save),
                                 onClick = {
+                                    if (webDavConfiguring) return@BrutalistButton  // Prevent concurrent attempts
+                                    webDavConfiguring = true
                                     scope.launch {
                                         val result = webDavBackend.configure(mapOf(
                                             "serverUrl" to webDavServerUrl,
@@ -666,6 +674,7 @@ fun ConfigScreen(
                                             "password" to webDavPassword,
                                             "basePath" to webDavBasePath,
                                         ))
+                                        webDavConfiguring = false
                                         if (result.isSuccess) {
                                             webDavConfigured = true
                                             showWebDavDialog = false
@@ -678,6 +687,7 @@ fun ConfigScreen(
                                 variant = ButtonVariant.Primary,
                                 modifier = Modifier.weight(1f),
                                 useMonoFont = true,
+                                enabled = !webDavConfiguring,
                             )
                         }
                     }

--- a/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/config/ConfigScreen.kt
@@ -54,6 +54,7 @@ import com.lockit.R
 import com.lockit.data.database.LockitDatabase
 import com.lockit.data.biometric.BiometricPinStorage
 import com.lockit.data.sync.GoogleDriveSyncManager
+import com.lockit.data.sync.WebDavBackend
 import com.lockit.data.updater.AppUpdater
 import com.lockit.data.updater.GitHubRelease
 import com.lockit.domain.model.Credential
@@ -158,6 +159,20 @@ fun ConfigScreen(
     var isSyncing by remember { mutableStateOf(false) }
     var syncStatus by remember { mutableStateOf<String?>(null) }
     var lastBackupTime by remember { mutableStateOf<String?>(null) }
+
+    // WebDAV sync
+    val webDavBackend = remember { WebDavBackend(context) }
+    var webDavConfigured by remember { mutableStateOf(false) }
+    var showWebDavDialog by remember { mutableStateOf(false) }
+    var webDavServerUrl by remember { mutableStateOf("") }
+    var webDavUsername by remember { mutableStateOf("") }
+    var webDavPassword by remember { mutableStateOf("") }
+    var webDavBasePath by remember { mutableStateOf("/lockit-sync") }
+
+    // Check WebDAV configuration status on init
+    LaunchedEffect(Unit) {
+        webDavConfigured = webDavBackend.isConfigured()
+    }
 
     // Google Sign-In launcher
     val signInLauncher = rememberLauncherForActivityResult(
@@ -532,6 +547,142 @@ fun ConfigScreen(
                     }
                 },
             )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // WebDAV Sync Section
+            ConfigSection(
+                title = stringResource(R.string.config_webdav),
+                content = {
+                    Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        // WebDAV status
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .border(1.dp, MaterialTheme.colorScheme.outline)
+                                .padding(8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                text = if (webDavConfigured) stringResource(R.string.config_webdav_connected) else stringResource(R.string.config_webdav_not_configured),
+                                fontFamily = JetBrainsMonoFamily,
+                                fontSize = 9.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = if (webDavConfigured) IndustrialOrange else MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+
+                        // WebDAV configure button
+                        BrutalistButton(
+                            text = stringResource(R.string.config_webdav_configure),
+                            onClick = { showWebDavDialog = true },
+                            variant = ButtonVariant.Primary,
+                            modifier = Modifier.fillMaxWidth(),
+                            useMonoFont = true,
+                        )
+
+                        if (webDavConfigured) {
+                            BrutalistButton(
+                                text = stringResource(R.string.config_webdav_clear),
+                                onClick = {
+                                    // Clear WebDAV configuration
+                                    webDavBackend.clearConfig()
+                                    webDavConfigured = false
+                                    toastMessage = context.getString(R.string.toast_signed_out)
+                                },
+                                variant = ButtonVariant.Warning,
+                                modifier = Modifier.fillMaxWidth(),
+                                useMonoFont = true,
+                            )
+                        }
+                    }
+                },
+            )
+
+            // WebDAV Configuration Dialog
+            if (showWebDavDialog) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f))
+                        .clickable(enabled = false) {},
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth(0.9f)
+                            .background(MaterialTheme.colorScheme.surface)
+                            .border(2.dp, MaterialTheme.colorScheme.primary)
+                            .padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        Text(
+                            text = stringResource(R.string.config_webdav_configure),
+                            fontFamily = JetBrainsMonoFamily,
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 14.sp,
+                            color = IndustrialOrange,
+                        )
+                        BrutalistTextField(
+                            value = webDavServerUrl,
+                            onValueChange = { webDavServerUrl = it },
+                            label = stringResource(R.string.config_webdav_server_url),
+                            placeholder = "https://dav.jianguoyun.com/dav/",
+                        )
+                        BrutalistTextField(
+                            value = webDavUsername,
+                            onValueChange = { webDavUsername = it },
+                            label = stringResource(R.string.config_webdav_username),
+                            placeholder = "user@example.com",
+                        )
+                        BrutalistTextField(
+                            value = webDavPassword,
+                            onValueChange = { webDavPassword = it },
+                            label = stringResource(R.string.config_webdav_password),
+                            placeholder = "app_password",
+                            isPassword = true,
+                        )
+                        BrutalistTextField(
+                            value = webDavBasePath,
+                            onValueChange = { webDavBasePath = it },
+                            label = stringResource(R.string.config_webdav_base_path),
+                            placeholder = "/lockit-sync",
+                        )
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            BrutalistButton(
+                                text = stringResource(R.string.btn_cancel),
+                                onClick = { showWebDavDialog = false },
+                                variant = ButtonVariant.Secondary,
+                                modifier = Modifier.weight(1f),
+                                useMonoFont = true,
+                            )
+                            BrutalistButton(
+                                text = stringResource(R.string.config_webdav_save),
+                                onClick = {
+                                    scope.launch {
+                                        val result = webDavBackend.configure(mapOf(
+                                            "serverUrl" to webDavServerUrl,
+                                            "username" to webDavUsername,
+                                            "password" to webDavPassword,
+                                            "basePath" to webDavBasePath,
+                                        ))
+                                        if (result.isSuccess) {
+                                            webDavConfigured = true
+                                            showWebDavDialog = false
+                                            toastMessage = context.getString(R.string.toast_webdav_configured)
+                                        } else {
+                                            toastMessage = "${context.getString(R.string.toast_webdav_error)} ${result.exceptionOrNull()?.message}"
+                                        }
+                                    }
+                                },
+                                variant = ButtonVariant.Primary,
+                                modifier = Modifier.weight(1f),
+                                useMonoFont = true,
+                            )
+                        }
+                    }
+                }
+            }
 
             Spacer(modifier = Modifier.height(24.dp))
 

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -108,6 +108,20 @@
     <string name="config_sync_drive">同步到Drive</string>
     <string name="config_sign_out">退出登录</string>
 
+    <!-- WebDAV Sync -->
+    <string name="config_webdav">WebDAV同步</string>
+    <string name="config_webdav_configure">配置WebDAV</string>
+    <string name="config_webdav_server_url">服务器地址</string>
+    <string name="config_webdav_username">用户名</string>
+    <string name="config_webdav_password">密码</string>
+    <string name="config_webdav_base_path">基础路径</string>
+    <string name="config_webdav_save">保存</string>
+    <string name="config_webdav_clear">清除</string>
+    <string name="config_webdav_connected">WebDAV已连接</string>
+    <string name="config_webdav_not_configured">未配置</string>
+    <string name="toast_webdav_configured">WebDAV已配置</string>
+    <string name="toast_webdav_error">WebDAV错误:</string>
+
     <string name="config_security">安全信息</string>
     <string name="config_salt_length">盐值长度</string>
     <string name="config_nonce_length">Nonce长度</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -107,6 +107,20 @@
     <string name="config_sync_drive">SYNC_TO_DRIVE</string>
     <string name="config_sign_out">SIGN_OUT</string>
 
+    <!-- WebDAV Sync -->
+    <string name="config_webdav">WEBDAV_SYNC</string>
+    <string name="config_webdav_configure">CONFIGURE_WEBDAV</string>
+    <string name="config_webdav_server_url">SERVER_URL</string>
+    <string name="config_webdav_username">USERNAME</string>
+    <string name="config_webdav_password">PASSWORD</string>
+    <string name="config_webdav_base_path">BASE_PATH</string>
+    <string name="config_webdav_save">SAVE</string>
+    <string name="config_webdav_clear">CLEAR</string>
+    <string name="config_webdav_connected">WEBDAV_CONNECTED</string>
+    <string name="config_webdav_not_configured">NOT_CONFIGURED</string>
+    <string name="toast_webdav_configured">WEBDAV_CONFIGURED</string>
+    <string name="toast_webdav_error">WEBDAV_ERROR:</string>
+
     <string name="config_security">SECURITY_INFO</string>
     <string name="config_salt_length">SALT_LENGTH</string>
     <string name="config_nonce_length">NONCE_LENGTH</string>


### PR DESCRIPTION
## Summary
- Add WebDAV configuration section in ConfigScreen (Settings page)
- Add configuration dialog with server URL, username, password, base path fields
- Add `clearConfig` method to WebDavBackend
- Add string resources for WebDAV UI (EN/ZH)

## Changes
- `ConfigScreen.kt`: Add WebDAV state variables, configuration section, and dialog
- `WebDavBackend.kt`: Add `clearConfig()` method for clearing stored credentials
- `strings.xml` / `strings-zh.xml`: Add WebDAV UI strings

## Test plan
- [x] Build passes
- [ ] Open Config screen, verify WebDAV section appears
- [ ] Click "CONFIGURE_WEBDAV", verify dialog opens
- [ ] Enter WebDAV credentials, click Save
- [ ] Verify "WEBDAV_CONNECTED" status appears
- [ ] Click Clear, verify configuration cleared

Closes #187 (P1: WebDAV config UI entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)