### PR TITLE
fix: COPY button copies plain value instead of structured JSON on first click

### DIFF
--- a/app/src/main/java/com/lockit/ui/components/CredentialCard.kt
+++ b/app/src/main/java/com/lockit/ui/components/CredentialCard.kt
@@ -186,8 +186,8 @@ fun CredentialCard(
     onClick: () -> Unit,
     /** Unified copy callback - receives CopyAction to determine what to copy */
     onCopy: (CopyAction) -> Unit,
-    /** Request biometric reveal before sensitive operations */
-    onNeedReveal: () -> Unit = {},
+    /** Request biometric reveal before sensitive operations. Optional callback invoked after reveal succeeds. */
+    onNeedReveal: (onSuccess: (() -> Unit)?) -> Unit = {},
     onDelete: () -> Unit,
     onEdit: () -> Unit,
     /** External reveal state management */
@@ -240,7 +240,7 @@ fun CredentialCard(
                         if (localRevealed || alwaysVisible) {
                             onCopy(CopyAction.STRUCTURED)
                         } else {
-                            onNeedReveal()
+                            onNeedReveal(null)
                         }
                     }
                 )
@@ -258,7 +258,7 @@ fun CredentialCard(
                     currentOnHide.value()
                 } else {
                     // Trigger biometric auth before revealing - don't bypass security
-                    onNeedReveal()
+                    onNeedReveal(null)
                 }
             },
             onCopy = { onCopy(CopyAction.VALUE) },
@@ -298,9 +298,9 @@ fun CredentialCard(
                 text = "COPY",
                 onClick = {
                     if (localRevealed || alwaysVisible) {
-                        onCopy(CopyAction.STRUCTURED)
+                        onCopy(CopyAction.VALUE)
                     } else {
-                        onNeedReveal()
+                        onNeedReveal { onCopy(CopyAction.VALUE) }
                     }
                 },
                 variant = ButtonVariant.Secondary,
@@ -402,7 +402,7 @@ private fun CredentialContent(
     isRevealed: Boolean,
     maskPlaceholder: String,
     onCopy: (CopyAction) -> Unit,
-    onNeedReveal: () -> Unit,
+    onNeedReveal: ((() -> Unit)?) -> Unit,
     onHide: () -> Unit,
     clipboardManager: androidx.compose.ui.platform.ClipboardManager,
 ) {
@@ -450,7 +450,7 @@ private fun CredentialContent(
                 IconButtonBox(
                     icon = if (isRevealed) Icons.Default.VisibilityOff else Icons.Default.Visibility,
                     description = if (isRevealed) "Hide" else "Reveal",
-                    onClick = { if (!isRevealed) onNeedReveal() else onHide() },
+                    onClick = { if (!isRevealed) onNeedReveal(null) else onHide() },
                 )
             }
             Spacer(modifier = Modifier.height(4.dp))
@@ -525,7 +525,7 @@ private fun CredentialContent(
                 isRevealed = isRevealed,
                 maskPlaceholder = maskPlaceholder,
                 maxLinesRevealed = 3,
-                onNeedReveal = onNeedReveal,
+                onNeedReveal = { onNeedReveal(null) },
                 onHide = onHide,
                 onCopy = { onCopy(CopyAction.API_KEY) },
                 clipboardManager = clipboardManager,
@@ -551,7 +551,7 @@ private fun CredentialContent(
                 isRevealed = isRevealed,
                 maskPlaceholder = maskPlaceholder,
                 maxLinesRevealed = 5,
-                onNeedReveal = onNeedReveal,
+                onNeedReveal = { onNeedReveal(null) },
                 onHide = onHide,
                 onCopy = { onCopy(CopyAction.VALUE) },
                 clipboardManager = clipboardManager,
@@ -589,7 +589,7 @@ private fun CredentialContent(
                 IconButtonBox(
                     icon = if (isRevealed) Icons.Default.VisibilityOff else Icons.Default.Visibility,
                     description = if (isRevealed) "Hide" else "Reveal",
-                    onClick = { if (!isRevealed) onNeedReveal() else onHide() },
+                    onClick = { if (!isRevealed) onNeedReveal(null) else onHide() },
                 )
             }
             Spacer(modifier = Modifier.height(4.dp))

--- a/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
@@ -640,7 +640,7 @@ fun ReposScreen(
                         cardRevealed = false
                         pendingRevealAction = null
                     },
-                    onNeedReveal = {
+                    onNeedReveal = { postReveal: (() -> Unit)? ->
                         val activity = getActivity()
                         val credToReveal = cred  // Capture credential for audit logging
                         if (activity != null) {
@@ -652,16 +652,19 @@ fun ReposScreen(
                                     onSuccess = {
                                         cardRevealed = true
                                         credToReveal?.let { app.vaultManager.logCredentialViewed(it.name) }
+                                        postReveal?.invoke()
                                     },
                                     onError = { pendingRevealAction = {
                                         cardRevealed = true
                                         credToReveal?.let { app.vaultManager.logCredentialViewed(it.name) }
+                                        postReveal?.invoke()
                                     } },
                                 )
                             } else {
                                 pendingRevealAction = {
                                     cardRevealed = true
                                     credToReveal?.let { app.vaultManager.logCredentialViewed(it.name) }
+                                    postReveal?.invoke()
                                 }
                             }
                         }
@@ -1012,7 +1015,7 @@ internal fun CredentialCardModal(
     onCopy: (CopyAction) -> Unit,
     onDelete: () -> Unit,
     onEdit: () -> Unit,
-    onNeedReveal: () -> Unit = {},
+    onNeedReveal: ((() -> Unit)?) -> Unit = {},
     isRevealed: Boolean = false,
     onHide: () -> Unit = {},
 ) {

--- a/app/src/main/java/com/lockit/ui/screens/vault_explorer/VaultExplorerScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/vault_explorer/VaultExplorerScreen.kt
@@ -239,9 +239,10 @@ fun VaultExplorerScreen(
         }
     }
 
-    fun handleReveal(credential: Credential) {
+    fun handleReveal(credential: Credential, onSuccess: (() -> Unit)? = null) {
         if (BiometricUtils.isSessionValid()) {
             revealedCredentialIds.add(credential.id)
+            onSuccess?.invoke()
             return
         }
         val activity = getActivity()
@@ -250,11 +251,22 @@ fun VaultExplorerScreen(
                 activity = activity,
                 title = biometricRevealTitle,
                 subtitle = biometricRevealSubtitle,
-                onSuccess = { revealedCredentialIds.add(credential.id) },
-                onError = { pendingBiometricAction = { revealedCredentialIds.add(credential.id) } },
+                onSuccess = {
+                    revealedCredentialIds.add(credential.id)
+                    onSuccess?.invoke()
+                },
+                onError = {
+                    pendingBiometricAction = {
+                        revealedCredentialIds.add(credential.id)
+                        onSuccess?.invoke()
+                    }
+                },
             )
         } else {
-            pendingBiometricAction = { revealedCredentialIds.add(credential.id) }
+            pendingBiometricAction = {
+                revealedCredentialIds.add(credential.id)
+                onSuccess?.invoke()
+            }
         }
     }
 
@@ -419,7 +431,7 @@ fun VaultExplorerScreen(
                             }
                         }
                     },
-                    onNeedReveal = { handleReveal(credential) },
+                    onNeedReveal = { onSuccess -> handleReveal(credential, onSuccess) },
                     onDelete = { viewModel.deleteCredential(credential) },
                     onEdit = { onNavigateToEdit(credential.id) },
                     isRevealed = revealedCredentialIds.contains(credential.id),


### PR DESCRIPTION
## Summary
- COPY button now copies `CopyAction.VALUE` (plain text) instead of `CopyAction.STRUCTURED` (JSON)
- First COPY click triggers biometric reveal + copies plain value in one flow — no more "first click does nothing"
- Added optional post-reveal callback to `onNeedReveal` to support reveal-then-copy pattern

## Changes
- `CredentialCard.kt`: Changed COPY button behavior, updated `onNeedReveal` signature chain
- `ReposScreen.kt`: `CredentialCardModal` invokes post-reveal callback after biometric succeeds
- `VaultExplorerScreen.kt`: `handleReveal` accepts and invokes optional post-success callback

## Test plan
- [ ] Open Repos screen, tap COPY on a sensitive credential → biometric → plain value copied to clipboard
- [ ] Second COPY tap on same credential → plain value copied directly (no re-auth)
- [ ] Long press → still copies structured JSON
- [ ] Vault Explorer COPY button → same behavior (value, not JSON)
- [ ] Non-sensitive types (Phone/IdCard/Note) → COPY copies value directly