### PR TITLE
fix: OAuth popup close navigates to root instead of reloading /auth/login

### DIFF
--- a/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
+++ b/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
@@ -607,9 +607,11 @@ class OAuthWebChromeClient(
         popupWebViews.remove(window)
         window?.destroy()
 
-        // When popup closes, trigger main WebView to check login status
+        // When popup closes, navigate to root so the SPA can detect session cookie
+        // and auto-redirect away from /auth. reload() keeps the page on /auth/login,
+        // which causes cookie polling's URL check to always fail.
         activity.authWebViewClient?.resetExtractionState()
-        activity.webView?.reload()
+        activity.webView?.loadUrl("https://chatgpt.com/")
     }
 
     /**

--- a/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
+++ b/app/src/main/java/com/lockit/ui/screens/auth/WebViewAuthActivity.kt
@@ -607,11 +607,16 @@ class OAuthWebChromeClient(
         popupWebViews.remove(window)
         window?.destroy()
 
-        // When popup closes, navigate to root so the SPA can detect session cookie
-        // and auto-redirect away from /auth. reload() keeps the page on /auth/login,
-        // which causes cookie polling's URL check to always fail.
+        // When popup closes, navigate to provider root so the SPA detects session
+        // cookie and auto-redirects away from login page. reload() keeps the page
+        // on /auth/login, which causes cookie polling's URL check to always fail.
         activity.authWebViewClient?.resetExtractionState()
-        activity.webView?.loadUrl("https://chatgpt.com/")
+        val rootUrl = when (provider) {
+            "chatgpt" -> "https://chatgpt.com/"
+            "claude" -> "https://claude.ai/"
+            else -> "https://chatgpt.com/" // fallback, only chatgpt/claude use OAuth popups
+        }
+        activity.webView?.loadUrl(rootUrl)
     }
 
     /**


### PR DESCRIPTION
## Summary
`onCloseWindow()` was calling `reload()` which kept the main WebView on `/auth/login`. Cookie polling's URL check (`!currentUrl.contains("/auth")`) always failed, so login was never detected after Google OAuth popup closed.

## Root Cause
Three issues chained together to break Google OAuth login:
1. `onCloseWindow()` → `reload()` kept the page on `/auth/login`
2. Cookie polling required `!currentUrl.contains("/auth")` → always false
3. Session cookie was in CookieManager but detection never triggered

## Fix
Changed `reload()` to `loadUrl("https://chatgpt.com/")` — navigates to root so ChatGPT SPA detects the session cookie and auto-redirects away from `/auth`.

## Test plan
- [ ] ChatGPT → Continue with Google → complete OAuth in popup → popup auto-closes → credentials extracted
- [ ] Non-ChatGPT OAuth flows not affected (the `loadUrl` is in OAuthWebChromeClient shared by all providers)
- [ ] Manual popup close still works (user closes before completing OAuth)