### PR TITLE
fix: Bailian catch block missing apiKey + cookie expiry detection

### DIFF
--- a/app/src/main/java/com/lockit/domain/qwen/BailianAuthClient.kt
+++ b/app/src/main/java/com/lockit/domain/qwen/BailianAuthClient.kt
@@ -41,6 +41,7 @@ object BailianAuthClient {
                 mapOf(
                     "provider" to "qwen_bailian",
                     "cookie" to cookie,
+                    "apiKey" to "",
                     "rawCurl" to buildCurlCommand(cookie),
                     "baseUrl" to "https://coding.dashscope.aliyuncs.com/v1"
                 )

--- a/app/src/main/java/com/lockit/domain/qwen/QwenCodingPlan.kt
+++ b/app/src/main/java/com/lockit/domain/qwen/QwenCodingPlan.kt
@@ -23,6 +23,10 @@ import java.net.URL
 object QwenCodingPlan : CodingPlanFetcher {
     override val providerKey: String = "qwen_bailian"
 
+    /** Exposed for ViewModel to check auth failure type after null result. */
+    var lastHttpStatus: Int = 0
+        private set
+
     private const val API_URL = "https://bailian-cs.console.aliyun.com/data/api.json" +
         "?action=BroadScopeAspnGateway&product=sfm_bailian" +
         "&api=zeldaEasy.broadscope-bailian.codingPlan.queryCodingPlanInstanceInfoV2"
@@ -43,15 +47,14 @@ object QwenCodingPlan : CodingPlanFetcher {
         val url = URL(API_URL)
         val conn = url.openConnection() as HttpURLConnection
 
-        // 设置超时：连接 5秒，读取 10秒
         conn.connectTimeout = 5000
         conn.readTimeout = 10000
-        // 禁用缓存，加速响应
         conn.useCaches = false
 
         conn.setupHeaders(cookie)
         conn.writeBody()
 
+        lastHttpStatus = conn.responseCode
         val response = conn.readResponse()
         conn.disconnect()
 

--- a/app/src/main/java/com/lockit/domain/qwen/QwenCodingPlan.kt
+++ b/app/src/main/java/com/lockit/domain/qwen/QwenCodingPlan.kt
@@ -24,6 +24,7 @@ object QwenCodingPlan : CodingPlanFetcher {
     override val providerKey: String = "qwen_bailian"
 
     /** Exposed for ViewModel to check auth failure type after null result. */
+    @Volatile
     var lastHttpStatus: Int = 0
         private set
 
@@ -44,6 +45,7 @@ object QwenCodingPlan : CodingPlanFetcher {
         }
 
     private fun fetchFromApi(cookie: String): CodingPlanQuota? {
+        lastHttpStatus = 0 // reset before each request to avoid stale data
         val url = URL(API_URL)
         val conn = url.openConnection() as HttpURLConnection
 

--- a/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
@@ -228,8 +228,12 @@ class ReposViewModel(app: LockitApp) : ViewModel() {
             _codingPlanQuota.value = result
             CodingPlanPrefetchState.setQuota(result)
             if (result == null && codingPlanCreds.isNotEmpty()) {
-                _codingPlanQuotaError.value = "NO_QUOTA_DATA"
-                CodingPlanPrefetchState.setError("NO_QUOTA_DATA")
+                val status = com.lockit.domain.qwen.QwenCodingPlan.lastHttpStatus
+                _codingPlanQuotaError.value = when {
+                    status in listOf(302, 401, 403) -> "COOKIE_EXPIRED"
+                    else -> "NO_QUOTA_DATA"
+                }
+                CodingPlanPrefetchState.setError(_codingPlanQuotaError.value)
             } else {
                 CodingPlanPrefetchState.setError(null)
                 // Save to cache for next startup
@@ -1215,7 +1219,7 @@ private fun CodingPlanBoard(
                     Text(
                         text = when (error) {
                             "NO_QUOTA_DATA" -> stringResource(R.string.repos_quota_fetch_failed)
-                            "NOT_LOGIN" -> stringResource(R.string.repos_quota_cookie_expired)
+                            "NOT_LOGIN", "COOKIE_EXPIRED" -> stringResource(R.string.repos_quota_cookie_expired)
                             null -> stringResource(R.string.repos_quota_no_data)
                             else -> error
                         },

--- a/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
+++ b/app/src/main/java/com/lockit/ui/screens/repos/ReposScreen.kt
@@ -228,11 +228,10 @@ class ReposViewModel(app: LockitApp) : ViewModel() {
             _codingPlanQuota.value = result
             CodingPlanPrefetchState.setQuota(result)
             if (result == null && codingPlanCreds.isNotEmpty()) {
-                val status = com.lockit.domain.qwen.QwenCodingPlan.lastHttpStatus
-                _codingPlanQuotaError.value = when {
-                    status in listOf(302, 401, 403) -> "COOKIE_EXPIRED"
-                    else -> "NO_QUOTA_DATA"
-                }
+                // Only check Qwen-specific HTTP status for qwen_bailian provider
+                val isExpired = targetProvider == "qwen_bailian" &&
+                    com.lockit.domain.qwen.QwenCodingPlan.lastHttpStatus in listOf(302, 401, 403)
+                _codingPlanQuotaError.value = if (isExpired) "COOKIE_EXPIRED" else "NO_QUOTA_DATA"
                 CodingPlanPrefetchState.setError(_codingPlanQuotaError.value)
             } else {
                 CodingPlanPrefetchState.setError(null)


### PR DESCRIPTION
## Summary

Three fixes for CodingPlan Board fetch failures and WebView API_KEY population:

1. **BailianAuthClient catch block**: Now includes `"apiKey"` field even when `fetchApiKeys()` throws — WebView login always populates the API_KEY field
2. **Cookie expiry detection**: `QwenCodingPlan` now tracks `lastHttpStatus`; when 302/401/403, shows "Cookie expired" instead of generic "Fetch failed"
3. The existing `repos_quota_cookie_expired` string ("Cookie expired") is reused for the new `COOKIE_EXPIRED` error code

## Test plan
- [ ] WebView login for 百炼 → API_KEY field populated even on network error
- [ ] Expired cookie → Coding Plan Board shows "Cookie expired" instead of "Fetch failed"
- [ ] Valid cookie → Board works as before