### PR TITLE
feat: remove preset dropdowns — all credential fields now plain text

### DIFF
--- a/app/src/main/java/com/lockit/domain/model/CredentialType.kt
+++ b/app/src/main/java/com/lockit/domain/model/CredentialType.kt
@@ -17,111 +17,68 @@ enum class CredentialType(
     val displayName: String,
     val iconHint: String,
     val description: String,
-    val fields: List<CredentialField>,
+    val fields: List<CredentialField>
 ) {
     ApiKey(
         "API_KEY", "key",
         "Store API keys for AI services, cloud providers, or any REST API. Used by agents for authentication.",
         listOf(
-            CredentialField("NAME", "e.g. OPENAI_API_KEY", presets = listOf(
-                "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "CLAUDE_API_KEY", "GEMINI_API_KEY",
-                "MINIMAX_API_KEY", "DEEPSEEK_API_KEY", "QWEN_API_KEY", "KIMI_API_KEY",
-                "XIAOMI_API_KEY", "GITHUB_TOKEN", "GLM_API_KEY", "CUSTOM",
-            ), isDropdown = true),
-            CredentialField("SERVICE", "e.g. openai, anthropic...", presets = listOf(
-                "openai", "anthropic", "google", "minimax",
-                "deepseek", "qwen", "kimi", "xiaomi",
-                "github", "glm",
-            ), isDropdown = true),
-            CredentialField("KEY_IDENTIFIER", "e.g. default, production...", presets = listOf(
-                "default", "production", "staging", "development",
-            ), isDropdown = true),
-            CredentialField("SECRET_VALUE", "Paste or enter the secret..."),
-        ),
+            CredentialField("NAME", "e.g. OPENAI_API_KEY"),
+            CredentialField("SERVICE", "e.g. openai, anthropic..."),
+            CredentialField("KEY_IDENTIFIER", "e.g. default, production..."),
+            CredentialField("SECRET_VALUE", "Paste or enter the secret...")
+        )
     ),
     GitHub(
         "GITHUB", "github",
         "Store GitHub credentials for private repo access, CI/CD, and agent git operations. Supports PAT, SSH, OAuth, and GitHub App.",
         listOf(
-            CredentialField("NAME", "e.g. GITHUB_TOKEN, CI_BOT", presets = listOf(
-                "GITHUB_TOKEN", "CI_BOT", "RELEASE_BOT", "PERSONAL_PAT", "ORG_PAT", "CUSTOM",
-            ), isDropdown = true),
-            CredentialField("TOKEN_TYPE", "Select token type", presets = listOf(
-                "Personal Access Token", "SSH Key", "OAuth App", "GitHub App",
-            ), isDropdown = true, editable = false),
+            CredentialField("NAME", "e.g. GITHUB_TOKEN, CI_BOT"),
+            CredentialField("TOKEN_TYPE", "Select token type"),
             CredentialField("ACCOUNT", "GitHub username (e.g. octocat)..."),
             CredentialField("TOKEN_VALUE", "Paste token or SSH key..."),
-            CredentialField("SCOPE", "Select scopes (multi-select)", presets = listOf(
-                "repo", "workflow", "admin:org", "admin:repo_hook", "write:packages",
-                "read:packages", "delete:packages", "gist", "user", "read:user",
-                "user:email", "user:follow", "read:org", "write:org",
-                "public_repo", "repo:status", "repo_deployment", "security_events",
-            ), isDropdown = false, showAsChips = true),
-        ),
+            CredentialField("SCOPE", "Select scopes (multi-select)")
+        )
     ),
     Account(
         "ACCOUNT", "account_circle",
         "Store login credentials for websites or apps. Agent can use these to auto-fill login forms.",
         listOf(
             CredentialField("USERNAME", "Enter username..."),
-            CredentialField("SERVICE", "e.g. google, github, netflix...", presets = listOf(
-                "google", "github", "apple", "netflix", "amazon", "twitter", "facebook",
-                "wechat", "alipay", "taobao", "jd", "douyin", "bilibili", "weibo", "xiaohongshu", "qq", "tencent",
-            ), isDropdown = false, showAsChips = true),
+            CredentialField("SERVICE", "e.g. google, github, netflix..."),
             CredentialField("EMAIL", "Associated email (optional)..."),
-            CredentialField("PASSWORD", "Enter password..."),
-        ),
+            CredentialField("PASSWORD", "Enter password...")
+        )
     ),
     CodingPlan(
         "CODING_PLAN", "code",
         "Store coding agent plan tokens. Paste your curl command or enter credentials manually.",
         listOf(
-            CredentialField("PROVIDER", "Select provider", presets = listOf(
-                "qwen_bailian", "openai", "anthropic", "google", "deepseek",
-                "minimax", "glm", "moonshot", "volcengine", "tencent",
-            ), isDropdown = true),
+            CredentialField("PROVIDER", "Select provider"),
             CredentialField("RAW_CURL", "Paste curl command (auto-extracts all fields)..."),
             CredentialField("API_KEY", "API key (required)...", required = true),
             CredentialField("COOKIE", "Bailian console cookie..."),
-            CredentialField("BASE_URL", "Select base URL (required)", presets = listOf(
-                "https://coding.dashscope.aliyuncs.com/v1",
-                "https://coding.dashscope.aliyuncs.com/apps/anthropic",
-                "https://api.openai.com/v1",
-                "https://api.anthropic.com/v1",
-                "https://generativelanguage.googleapis.com/v1",
-                "https://api.deepseek.com/v1",
-                "https://api.moonshot.cn/v1",
-                "https://api.minimax.chat/v1",
-                "https://open.bigmodel.cn/api/paas/v4",
-                "https://bailian.console.aliyun.com",
-            ), isDropdown = true, editable = true, required = true),
-        ),
+            CredentialField("BASE_URL", "Select base URL (required)", required = true)
+        )
     ),
     Password(
         "PASSWORD", "password",
         "Store standalone passwords not tied to a specific account. Good for WiFi, router, or shared passwords.",
         listOf(
             CredentialField("PASSWORD_LABEL", "Enter password..."),
-            CredentialField("SERVICE", "e.g. google, github...", presets = listOf(
-                "google", "github", "apple", "netflix", "amazon", "twitter", "facebook",
-                "wechat", "alipay", "taobao", "jd", "douyin", "bilibili", "weibo", "xiaohongshu", "qq", "tencent",
-            ), isDropdown = false, showAsChips = true),
+            CredentialField("SERVICE", "e.g. google, github..."),
             CredentialField("USERNAME", "Associated username (optional)..."),
-            CredentialField("PASSWORD_VALUE", "Enter password again..."),
-        ),
+            CredentialField("PASSWORD_VALUE", "Enter password again...")
+        )
     ),
     Phone(
         "PHONE", "phone",
         "Store phone numbers with country codes. Agent can use these to verify identity or send SMS.",
         listOf(
-            CredentialField("REGION", "Select region", presets = listOf(
-                "+86 中国", "+1 美国", "+44 英国", "+81 日本", "+82 韩国",
-                "+852 香港", "+886 台湾", "+65 新加坡", "+91 印度", "+49 德国",
-                "+33 法国", "+61 澳洲", "+7 俄罗斯", "+55 巴西",
-            ), isDropdown = true, editable = false),
+            CredentialField("REGION", "Select region"),
             CredentialField("PHONE_NUMBER", "138 0000 0000"),
-            CredentialField("NOTE", "e.g. delivery, work contact..."),
-        ),
+            CredentialField("NOTE", "e.g. delivery, work contact...")
+        )
     ),
     BankCard(
         "BANK_CARD", "credit_card",
@@ -130,42 +87,31 @@ enum class CredentialType(
             CredentialField("CARD_NUMBER", "Card number..."),
             CredentialField("BANK", "e.g. ICBC, BOC, CMB..."),
             CredentialField("CARDHOLDER", "Cardholder name..."),
-            CredentialField("CVV_EXPIRY", "CVV or expiry (optional)..."),
-        ),
+            CredentialField("CVV_EXPIRY", "CVV or expiry (optional)...")
+        )
     ),
     Email(
         "EMAIL", "email",
         "Store email accounts with passwords, regions, and billing addresses. Agent can use for SMTP auth or account recovery.",
         listOf(
-            CredentialField("SERVICE", "Select provider", presets = listOf(
-                "@gmail.com", "@outlook.com", "@yahoo.com", "@protonmail.com", "@icloud.com", "@qq.com", "@163.com", "@126.com",
-            ), isDropdown = true, editable = true),
+            CredentialField("SERVICE", "Select provider"),
             CredentialField("EMAIL_PREFIX", "e.g. john.doe"),
             CredentialField("PASSWORD", "Password or app code..."),
-            CredentialField("REGION", "Select region...", presets = listOf(
-                "US-United States", "CA-Canada", "UK-United Kingdom", "CN-China",
-                "HK-Hong Kong", "TW-Taiwan", "JP-Japan", "SG-Singapore",
-            ), isDropdown = true, editable = true),
+            CredentialField("REGION", "Select region..."),
             CredentialField("STREET", "123 Main St, Apt 4B"),
             CredentialField("CITY", "New York"),
-            CredentialField("STATE_ZIP", "NY 10001"),
-        ),
+            CredentialField("STATE_ZIP", "NY 10001")
+        )
     ),
     Token(
         "TOKEN", "vpn_key",
         "Store bearer tokens, session tokens, or any auth tokens. Agent can inject these into API headers.",
         listOf(
             CredentialField("NAME", "e.g. JWT_TOKEN, SESSION_TOKEN"),
-            CredentialField("SERVICE", "e.g. my-app, staging...", presets = listOf(
-                "openai", "anthropic", "google", "minimax",
-                "deepseek", "qwen", "kimi", "xiaomi",
-                "github", "glm", "CUSTOM",
-            ), isDropdown = true),
-            CredentialField("KEY_IDENTIFIER", "e.g. default, production...", presets = listOf(
-                "default", "production", "staging", "development",
-            ), isDropdown = true),
-            CredentialField("TOKEN_VALUE", "Paste or enter the token..."),
-        ),
+            CredentialField("SERVICE", "e.g. my-app, staging..."),
+            CredentialField("KEY_IDENTIFIER", "e.g. default, production..."),
+            CredentialField("TOKEN_VALUE", "Paste or enter the token...")
+        )
     ),
     SshKey(
         "SSH_KEY", "lock",
@@ -173,11 +119,9 @@ enum class CredentialType(
         listOf(
             CredentialField("NAME", "e.g. GITHUB_SSH, AWS_SSH"),
             CredentialField("SERVICE", "e.g. github, aws, digitalocean..."),
-            CredentialField("KEY_IDENTIFIER", "e.g. ed25519, rsa-4096...", presets = listOf(
-                "ed25519", "rsa-4096", "rsa-2048", "ecdsa", "custom",
-            ), isDropdown = true),
-            CredentialField("PRIVATE_KEY", "Paste private key..."),
-        ),
+            CredentialField("KEY_IDENTIFIER", "e.g. ed25519, rsa-4096..."),
+            CredentialField("PRIVATE_KEY", "Paste private key...")
+        )
     ),
     WebhookSecret(
         "WEBHOOK_SECRET", "webhook",
@@ -186,8 +130,8 @@ enum class CredentialType(
             CredentialField("NAME", "e.g. GITHUB_WEBHOOK, STRIPE_SECRET"),
             CredentialField("SERVICE", "e.g. github, stripe, vercel..."),
             CredentialField("HEADER_KEY", "e.g. X-Hub-Signature..."),
-            CredentialField("SECRET_VALUE", "Paste or enter the webhook secret..."),
-        ),
+            CredentialField("SECRET_VALUE", "Paste or enter the webhook secret...")
+        )
     ),
     OAuthClient(
         "OAUTH_CLIENT", "login",
@@ -196,8 +140,8 @@ enum class CredentialType(
             CredentialField("NAME", "e.g. GOOGLE_OAUTH, GITHUB_APP"),
             CredentialField("SERVICE", "e.g. google, github, auth0..."),
             CredentialField("CLIENT_ID", "Enter client ID..."),
-            CredentialField("CLIENT_SECRET", "Paste client secret..."),
-        ),
+            CredentialField("CLIENT_SECRET", "Paste client secret...")
+        )
     ),
     AwsCredential(
         "AWS_CREDENTIAL", "cloud",
@@ -206,8 +150,8 @@ enum class CredentialType(
             CredentialField("NAME", "e.g. AWS_PROD, AWS_STAGING"),
             CredentialField("SERVICE", "e.g. aws, aws-prod, aws-dev..."),
             CredentialField("ACCESS_KEY", "Enter access key ID..."),
-            CredentialField("SECRET_KEY", "Paste secret key..."),
-        ),
+            CredentialField("SECRET_KEY", "Paste secret key...")
+        )
     ),
     GpgKey(
         "GPG_KEY", "shield",
@@ -216,8 +160,8 @@ enum class CredentialType(
             CredentialField("NAME", "e.g. PERSONAL_GPG, CI_SIGNING"),
             CredentialField("SERVICE", "e.g. personal, ci-cd..."),
             CredentialField("KEY_ID", "e.g. key fingerprint..."),
-            CredentialField("PRIVATE_KEY", "Paste GPG private key..."),
-        ),
+            CredentialField("PRIVATE_KEY", "Paste GPG private key...")
+        )
     ),
     DatabaseUrl(
         "DATABASE_URL", "storage",
@@ -225,11 +169,9 @@ enum class CredentialType(
         listOf(
             CredentialField("NAME", "e.g. POSTGRES_PROD, MONGO_STAGING"),
             CredentialField("SERVICE", "e.g. postgres, mongo, redis..."),
-            CredentialField("KEY_IDENTIFIER", "e.g. primary, replica...", presets = listOf(
-                "primary", "replica", "read-only", "staging",
-            ), isDropdown = true),
-            CredentialField("CONNECTION_URL", "Paste connection string..."),
-        ),
+            CredentialField("KEY_IDENTIFIER", "e.g. primary, replica..."),
+            CredentialField("CONNECTION_URL", "Paste connection string...")
+        )
     ),
     IdCard(
         "ID_CARD", "badge",
@@ -238,16 +180,16 @@ enum class CredentialType(
             CredentialField("CARDHOLDER", "Name on ID..."),
             CredentialField("ISSUER", "e.g. government, company..."),
             CredentialField("ID_NUMBER", "ID number..."),
-            CredentialField("EXTRA", "Notes (optional)..."),
-        ),
+            CredentialField("EXTRA", "Notes (optional)...")
+        )
     ),
     Note(
         "NOTE", "label",
         "Store freeform notes like WiFi passwords, server info, or any text that doesn't fit other types.",
         listOf(
             CredentialField("TITLE", "e.g. WiFi Password, Server Info..."),
-            CredentialField("TAGS", "e.g. wifi, network, home..."),
-        ),
+            CredentialField("TAGS", "e.g. wifi, network, home...")
+        )
     ),
     Custom(
         "CUSTOM", "label",
@@ -256,8 +198,8 @@ enum class CredentialType(
             CredentialField("NAME", "e.g. MY_CUSTOM_KEY"),
             CredentialField("SERVICE", "e.g. my-service..."),
             CredentialField("KEY", "custom_key_identifier"),
-            CredentialField("VALUE", "Paste or enter the secret..."),
-        ),
+            CredentialField("VALUE", "Paste or enter the secret...")
+        )
     );
 
     companion object {


### PR DESCRIPTION
## Summary
Removed all preset dropdowns, chip selectors, and non-editable fields from the Add/Edit Credential forms. All fields are now plain text inputs — users type freely instead of selecting from predefined lists.

## Changes
- Removed `presets`, `isDropdown`, `showAsChips`, `editable` from all 18 `CredentialType` field definitions
- Form rendering automatically falls through to plain `BrutalistTextField` since `isDropdown` and `showAsChips` are now always false
- No UI changes needed — the existing else-branch handles all fields correctly

## Test plan
- [ ] Add Credential screen: all fields show as plain text inputs (no dropdowns/chips)
- [ ] Edit Credential screen: same behavior
- [ ] All 18 credential types render correctly with plain fields
- [ ] Existing credentials not affected (storage format unchanged)